### PR TITLE
geom_alt props

### DIFF
--- a/data/101/870/551/101870551.geojson
+++ b/data/101/870/551/101870551.geojson
@@ -106,6 +106,9 @@
         "wk:page":"Eqalugaarsuit"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45fd99d5b37975e60b4ed08d7b18f946",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":101870551,
-    "wof:lastmodified":1566638823,
+    "wof:lastmodified":1582358137,
     "wof:name":"Eqalugaarsuit",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/555/101870555.geojson
+++ b/data/101/870/555/101870555.geojson
@@ -213,8 +213,9 @@
     "qs:type":"buffered point",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes_pg",
-        "quattroshapes"
+        "quattroshapes",
+        "naturalearth",
+        "quattroshapes_pg"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -237,6 +238,11 @@
         "qs_pg:id":228708
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"081c98b2b1ceb3cd1837b4ff9fe03198",
     "wof:hierarchy":[
         {
@@ -247,7 +253,7 @@
         }
     ],
     "wof:id":101870555,
-    "wof:lastmodified":1566638828,
+    "wof:lastmodified":1582358138,
     "wof:name":"Narsarsuaq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/557/101870557.geojson
+++ b/data/101/870/557/101870557.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Qassiarsuk"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"212ab216fb9efc57431b3991a5681e67",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101870557,
-    "wof:lastmodified":1566638823,
+    "wof:lastmodified":1582358137,
     "wof:name":"Qassiarsuk",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/561/101870561.geojson
+++ b/data/101/870/561/101870561.geojson
@@ -160,6 +160,10 @@
         "qs_pg:id":95528
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e60025359321e652642902f5f65d0d6a",
     "wof:hierarchy":[
         {
@@ -170,7 +174,7 @@
         }
     ],
     "wof:id":101870561,
-    "wof:lastmodified":1566638823,
+    "wof:lastmodified":1582358137,
     "wof:name":"Narsaq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/563/101870563.geojson
+++ b/data/101/870/563/101870563.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Igaliku"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6727e359a4a853f348b476e0b584a75",
     "wof:hierarchy":[
         {
@@ -128,7 +132,7 @@
         }
     ],
     "wof:id":101870563,
-    "wof:lastmodified":1566638829,
+    "wof:lastmodified":1582358138,
     "wof:name":"Igaliku",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/565/101870565.geojson
+++ b/data/101/870/565/101870565.geojson
@@ -291,6 +291,10 @@
         "qs_pg:id":1044559
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4c710a97b5b91777d713abbf13f79bd",
     "wof:hierarchy":[
         {
@@ -301,7 +305,7 @@
         }
     ],
     "wof:id":101870565,
-    "wof:lastmodified":1566638829,
+    "wof:lastmodified":1582358138,
     "wof:name":"Qaqortoq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/567/101870567.geojson
+++ b/data/101/870/567/101870567.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Ammassivik"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53168f4b891bd93479e8f82f29031e0e",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101870567,
-    "wof:lastmodified":1566638823,
+    "wof:lastmodified":1582358137,
     "wof:name":"Ammassivik",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/569/101870569.geojson
+++ b/data/101/870/569/101870569.geojson
@@ -127,6 +127,10 @@
         "wk:page":"Alluitsup Paa"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d403b1c8b097314bccf91fc0ed22239a",
     "wof:hierarchy":[
         {
@@ -137,7 +141,7 @@
         }
     ],
     "wof:id":101870569,
-    "wof:lastmodified":1566638823,
+    "wof:lastmodified":1582358137,
     "wof:name":"Alluitsup Paa",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/571/101870571.geojson
+++ b/data/101/870/571/101870571.geojson
@@ -99,6 +99,10 @@
         "wk:page":"Tasiusaq, Kujalleq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c707b3088ed1f682ee06f8c129df0f78",
     "wof:hierarchy":[
         {
@@ -109,7 +113,7 @@
         }
     ],
     "wof:id":101870571,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Tasiusaq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/573/101870573.geojson
+++ b/data/101/870/573/101870573.geojson
@@ -136,6 +136,9 @@
         "wk:page":"Aappilattoq, Kujalleq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4bac5be02ec7a12604332ddfc4425561",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":101870573,
-    "wof:lastmodified":1566638828,
+    "wof:lastmodified":1582358138,
     "wof:name":"Aappilattoq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/575/101870575.geojson
+++ b/data/101/870/575/101870575.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Narsaq Kujalleq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5330a47aef903a8a48f411a1ce4da9b5",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101870575,
-    "wof:lastmodified":1566638827,
+    "wof:lastmodified":1582358138,
     "wof:name":"Narsarmijit",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/579/101870579.geojson
+++ b/data/101/870/579/101870579.geojson
@@ -213,8 +213,9 @@
     "qs:type":"buffered point",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "quattroshapes",
         "quattroshapes_pg",
-        "quattroshapes"
+        "naturalearth"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -237,6 +238,11 @@
         "qs_pg:id":1044576
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"cfef0e459ef4c2e92760054cc660fc92",
     "wof:hierarchy":[
         {
@@ -247,7 +253,7 @@
         }
     ],
     "wof:id":101870579,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Kulusuk",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/581/101870581.geojson
+++ b/data/101/870/581/101870581.geojson
@@ -83,6 +83,9 @@
         "wd:id":"Q1019108"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19c205265fff488f2786f0d460ce54ff",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101870581,
-    "wof:lastmodified":1566638827,
+    "wof:lastmodified":1582358138,
     "wof:name":"Ikkatteq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/583/101870583.geojson
+++ b/data/101/870/583/101870583.geojson
@@ -249,6 +249,10 @@
         "wk:page":"Tasiilaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"beab3167c0e620fb89ab22bb0279699a",
     "wof:hierarchy":[
         {
@@ -259,7 +263,7 @@
         }
     ],
     "wof:id":101870583,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Tasiilaq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/585/101870585.geojson
+++ b/data/101/870/585/101870585.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bb79bba2b64c4a84656b54b0b284c50",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101870585,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Narsalik",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/587/101870587.geojson
+++ b/data/101/870/587/101870587.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Qeqertarsuatsiaat"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2400f00646972e9e9ae1cad6d1f41e73",
     "wof:hierarchy":[
         {
@@ -128,7 +132,7 @@
         }
     ],
     "wof:id":101870587,
-    "wof:lastmodified":1566638828,
+    "wof:lastmodified":1582358138,
     "wof:name":"Qeqertarsuatsiaat",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/589/101870589.geojson
+++ b/data/101/870/589/101870589.geojson
@@ -193,6 +193,10 @@
         "wk:page":"Ittoqqortoormiit"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dacacb6fd6c78a3a3173f4d6fc7b0532",
     "wof:hierarchy":[
         {
@@ -203,7 +207,7 @@
         }
     ],
     "wof:id":101870589,
-    "wof:lastmodified":1566638828,
+    "wof:lastmodified":1582358138,
     "wof:name":"Illoqqortoormiut",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/591/101870591.geojson
+++ b/data/101/870/591/101870591.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Itterajivit"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4fb9d47707be0ebdc56e38314b85eb65",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101870591,
-    "wof:lastmodified":1566638829,
+    "wof:lastmodified":1582358138,
     "wof:name":"Ittaajimmiit",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/593/101870593.geojson
+++ b/data/101/870/593/101870593.geojson
@@ -117,6 +117,9 @@
         "wd:id":"Q2527977"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c308f44fba4ac7aeb11148ca40f7a09",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101870593,
-    "wof:lastmodified":1566638823,
+    "wof:lastmodified":1582358137,
     "wof:name":"Uunarteq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/597/101870597.geojson
+++ b/data/101/870/597/101870597.geojson
@@ -166,6 +166,10 @@
         "wk:page":"Maniitsoq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82fe7e53c1df1991688990fb05e79b04",
     "wof:hierarchy":[
         {
@@ -176,7 +180,7 @@
         }
     ],
     "wof:id":101870597,
-    "wof:lastmodified":1566638829,
+    "wof:lastmodified":1582358138,
     "wof:name":"Maniitsoq",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/599/101870599.geojson
+++ b/data/101/870/599/101870599.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Kangaamiut"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b996fd1e50e2b25d98ac04ffbd57ba99",
     "wof:hierarchy":[
         {
@@ -128,7 +132,7 @@
         }
     ],
     "wof:id":101870599,
-    "wof:lastmodified":1566638829,
+    "wof:lastmodified":1582358138,
     "wof:name":"Kangaamiut",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/601/101870601.geojson
+++ b/data/101/870/601/101870601.geojson
@@ -306,6 +306,10 @@
         "wk:page":"Sisimiut"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad9455e62c83eb22d2002c2bce2979f9",
     "wof:hierarchy":[
         {
@@ -316,7 +320,7 @@
         }
     ],
     "wof:id":101870601,
-    "wof:lastmodified":1566638832,
+    "wof:lastmodified":1582358139,
     "wof:name":"Sisimiut",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/603/101870603.geojson
+++ b/data/101/870/603/101870603.geojson
@@ -124,6 +124,10 @@
         "wk:page":"Sarfannguit"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b40323ea6e1a96f18502b1f925e45c19",
     "wof:hierarchy":[
         {
@@ -134,7 +138,7 @@
         }
     ],
     "wof:id":101870603,
-    "wof:lastmodified":1566638826,
+    "wof:lastmodified":1582358138,
     "wof:name":"Sarfannguit",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/605/101870605.geojson
+++ b/data/101/870/605/101870605.geojson
@@ -129,6 +129,10 @@
         "wk:page":"Itilleq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f4ed9950dc96fdafc0e6cedf3ebd8a07",
     "wof:hierarchy":[
         {
@@ -139,7 +143,7 @@
         }
     ],
     "wof:id":101870605,
-    "wof:lastmodified":1566638826,
+    "wof:lastmodified":1582358138,
     "wof:name":"Itilleq",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/607/101870607.geojson
+++ b/data/101/870/607/101870607.geojson
@@ -124,6 +124,10 @@
         "wk:page":"Atammik"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dfcf04c7d0b182f5032ffe882f5ae6a3",
     "wof:hierarchy":[
         {
@@ -134,7 +138,7 @@
         }
     ],
     "wof:id":101870607,
-    "wof:lastmodified":1566638832,
+    "wof:lastmodified":1582358139,
     "wof:name":"Atammik",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/609/101870609.geojson
+++ b/data/101/870/609/101870609.geojson
@@ -217,6 +217,7 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "quattroshapes_pg",
+        "naturalearth",
         "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
@@ -237,6 +238,11 @@
         "wk:page":"Kangerlussuaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbca1ee26a9759b8a70918ca1b6744d6",
     "wof:hierarchy":[
         {
@@ -247,7 +253,7 @@
         }
     ],
     "wof:id":101870609,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Kangerlussuaq",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/611/101870611.geojson
+++ b/data/101/870/611/101870611.geojson
@@ -115,6 +115,10 @@
         "wk:page":"Sermiligaaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"26169fafc1dde41f264a028893656996",
     "wof:hierarchy":[
         {
@@ -125,7 +129,7 @@
         }
     ],
     "wof:id":101870611,
-    "wof:lastmodified":1566638826,
+    "wof:lastmodified":1582358138,
     "wof:name":"Sermiligaaq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/615/101870615.geojson
+++ b/data/101/870/615/101870615.geojson
@@ -121,6 +121,10 @@
         "wk:page":"Kuummiit"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"694c9b482d16a2cd94a3516c013c9400",
     "wof:hierarchy":[
         {
@@ -131,7 +135,7 @@
         }
     ],
     "wof:id":101870615,
-    "wof:lastmodified":1566638830,
+    "wof:lastmodified":1582358138,
     "wof:name":"Kuummiut",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/617/101870617.geojson
+++ b/data/101/870/617/101870617.geojson
@@ -109,6 +109,10 @@
         "wk:page":"Tiilerilaaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3c3df81dab92a570754ba35772b43112",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
         }
     ],
     "wof:id":101870617,
-    "wof:lastmodified":1566638824,
+    "wof:lastmodified":1582358137,
     "wof:name":"Tiniteqilaaq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/619/101870619.geojson
+++ b/data/101/870/619/101870619.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Isertoq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0de3074aa8b18bcc05dfc6052911318",
     "wof:hierarchy":[
         {
@@ -128,7 +132,7 @@
         }
     ],
     "wof:id":101870619,
-    "wof:lastmodified":1566638825,
+    "wof:lastmodified":1582358137,
     "wof:name":"Isortoq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/621/101870621.geojson
+++ b/data/101/870/621/101870621.geojson
@@ -109,6 +109,10 @@
         "wk:page":"Kapisillit"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"243a3d7722f72e0a38edd5543466a5d7",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
         }
     ],
     "wof:id":101870621,
-    "wof:lastmodified":1566638825,
+    "wof:lastmodified":1582358137,
     "wof:name":"Kapisillit",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/623/101870623.geojson
+++ b/data/101/870/623/101870623.geojson
@@ -914,6 +914,11 @@
         "wk:page":"Nuuk"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg",
+        "whosonfirst"
+    ],
     "wof:geomhash":"d2fb4c083dab67554756531bf0aaf6a4",
     "wof:hierarchy":[
         {
@@ -924,7 +929,7 @@
         }
     ],
     "wof:id":101870623,
-    "wof:lastmodified":1566638830,
+    "wof:lastmodified":1582358138,
     "wof:megacity":0,
     "wof:name":"Nuuk",
     "wof:parent_id":85684729,

--- a/data/101/870/625/101870625.geojson
+++ b/data/101/870/625/101870625.geojson
@@ -267,6 +267,10 @@
         "wk:page":"Paamiut"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e765c37950f3b9dcafaae04fd0c83bb",
     "wof:hierarchy":[
         {
@@ -277,7 +281,7 @@
         }
     ],
     "wof:id":101870625,
-    "wof:lastmodified":1566638829,
+    "wof:lastmodified":1582358138,
     "wof:name":"Paamiut",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/627/101870627.geojson
+++ b/data/101/870/627/101870627.geojson
@@ -124,6 +124,10 @@
         "wk:page":"Arsuk"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1628f8eadb7b4371440ef283d0342659",
     "wof:hierarchy":[
         {
@@ -134,7 +138,7 @@
         }
     ],
     "wof:id":101870627,
-    "wof:lastmodified":1566638825,
+    "wof:lastmodified":1582358137,
     "wof:name":"Arsuk",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/629/101870629.geojson
+++ b/data/101/870/629/101870629.geojson
@@ -136,6 +136,10 @@
         "wk:page":"Ivittuut"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7511a25c5c3caf6e8b918dcdee91fcbf",
     "wof:hierarchy":[
         {
@@ -146,7 +150,7 @@
         }
     ],
     "wof:id":101870629,
-    "wof:lastmodified":1566638826,
+    "wof:lastmodified":1582358137,
     "wof:name":"Ivittuut",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/633/101870633.geojson
+++ b/data/101/870/633/101870633.geojson
@@ -115,6 +115,10 @@
         "wk:page":"Attu, Greenland"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"24cbfd145349c627c544c4fe03fe1db4",
     "wof:hierarchy":[
         {
@@ -125,7 +129,7 @@
         }
     ],
     "wof:id":101870633,
-    "wof:lastmodified":1566638826,
+    "wof:lastmodified":1582358138,
     "wof:name":"Attu",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/635/101870635.geojson
+++ b/data/101/870/635/101870635.geojson
@@ -102,6 +102,10 @@
         "wk:page":"Ikamiut"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"52abc3f7733cae27f1596a0603addb3c",
     "wof:hierarchy":[
         {
@@ -112,7 +116,7 @@
         }
     ],
     "wof:id":101870635,
-    "wof:lastmodified":1566638827,
+    "wof:lastmodified":1582358138,
     "wof:name":"Ikamiut",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/637/101870637.geojson
+++ b/data/101/870/637/101870637.geojson
@@ -130,6 +130,10 @@
         "wk:page":"Akunnaaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"61bfd48bc1d46eb241b33cb2a7714105",
     "wof:hierarchy":[
         {
@@ -140,7 +144,7 @@
         }
     ],
     "wof:id":101870637,
-    "wof:lastmodified":1566638831,
+    "wof:lastmodified":1582358139,
     "wof:name":"Akunnaaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/639/101870639.geojson
+++ b/data/101/870/639/101870639.geojson
@@ -211,6 +211,10 @@
         "wk:page":"Aasiaat"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"671c0438769396679aee087ec8088adc",
     "wof:hierarchy":[
         {
@@ -221,7 +225,7 @@
         }
     ],
     "wof:id":101870639,
-    "wof:lastmodified":1566638832,
+    "wof:lastmodified":1582358139,
     "wof:name":"Aasiaat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/641/101870641.geojson
+++ b/data/101/870/641/101870641.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Qeqertaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8a6b46adddcf33492ba79e9c79cafdb0",
     "wof:hierarchy":[
         {
@@ -128,7 +132,7 @@
         }
     ],
     "wof:id":101870641,
-    "wof:lastmodified":1566638830,
+    "wof:lastmodified":1582358138,
     "wof:name":"Qeqertaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/643/101870643.geojson
+++ b/data/101/870/643/101870643.geojson
@@ -228,6 +228,7 @@
     "qs:type":"buffered point",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg",
         "quattroshapes"
     ],
@@ -252,6 +253,11 @@
         "wk:page":"Uummannaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7dd453cfe4f0ae92529c2edf7d1b8a39",
     "wof:hierarchy":[
         {
@@ -262,7 +268,7 @@
         }
     ],
     "wof:id":101870643,
-    "wof:lastmodified":1566638824,
+    "wof:lastmodified":1582358137,
     "wof:name":"Uummannaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/647/101870647.geojson
+++ b/data/101/870/647/101870647.geojson
@@ -101,6 +101,9 @@
         "wd:id":"Q2291039"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0077b8ba92a747a53928ca8c75546e86",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101870647,
-    "wof:lastmodified":1566638830,
+    "wof:lastmodified":1582358138,
     "wof:name":"Kangerluk",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/651/101870651.geojson
+++ b/data/101/870/651/101870651.geojson
@@ -169,6 +169,10 @@
         "wk:page":"Qeqertarsuaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ab089768cc501c5c0e4d7a7faf256bfd",
     "wof:hierarchy":[
         {
@@ -179,7 +183,7 @@
         }
     ],
     "wof:id":101870651,
-    "wof:lastmodified":1566638826,
+    "wof:lastmodified":1582358138,
     "wof:name":"Qeqertarsuaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/653/101870653.geojson
+++ b/data/101/870/653/101870653.geojson
@@ -115,6 +115,10 @@
         "wk:page":"Illorsuit"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"62fac27b88edaae6720112ea2a2f721b",
     "wof:hierarchy":[
         {
@@ -125,7 +129,7 @@
         }
     ],
     "wof:id":101870653,
-    "wof:lastmodified":1566638832,
+    "wof:lastmodified":1582358139,
     "wof:name":"Illorsuit",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/655/101870655.geojson
+++ b/data/101/870/655/101870655.geojson
@@ -109,6 +109,10 @@
         "wk:page":"Nuugaatsiaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d66acc64f2d36127e4df181bddc54b9",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
         }
     ],
     "wof:id":101870655,
-    "wof:lastmodified":1566638831,
+    "wof:lastmodified":1582358139,
     "wof:name":"Nuugaatsiaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/657/101870657.geojson
+++ b/data/101/870/657/101870657.geojson
@@ -115,6 +115,10 @@
         "wk:page":"Upernavik Kujalleq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"baffaba4f9ede9528457b2cd8f406bc8",
     "wof:hierarchy":[
         {
@@ -125,7 +129,7 @@
         }
     ],
     "wof:id":101870657,
-    "wof:lastmodified":1566638827,
+    "wof:lastmodified":1582358138,
     "wof:name":"Upernavik Kujalleq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/659/101870659.geojson
+++ b/data/101/870/659/101870659.geojson
@@ -139,6 +139,10 @@
         "wk:page":"Aappilattoq, Qaasuitsup"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c0e494dfea6c3b9053b913bde86bd0b7",
     "wof:hierarchy":[
         {
@@ -149,7 +153,7 @@
         }
     ],
     "wof:id":101870659,
-    "wof:lastmodified":1566638827,
+    "wof:lastmodified":1582358138,
     "wof:name":"Aappilattoq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/665/101870665.geojson
+++ b/data/101/870/665/101870665.geojson
@@ -110,6 +110,9 @@
         "wd:id":"Q2045888"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c42577ab9ea057664d0a16d6e5a23e6",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101870665,
-    "wof:lastmodified":1566638832,
+    "wof:lastmodified":1582358139,
     "wof:name":"Innaarsuit",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/671/101870671.geojson
+++ b/data/101/870/671/101870671.geojson
@@ -184,6 +184,7 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "quattroshapes_pg",
+        "naturalearth",
         "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
@@ -203,6 +204,11 @@
         "wk:page":"Tasiusaq, Qaasuitsup"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a21524837ce2d6ef08897416a8aba711",
     "wof:hierarchy":[
         {
@@ -213,7 +219,7 @@
         }
     ],
     "wof:id":101870671,
-    "wof:lastmodified":1566638829,
+    "wof:lastmodified":1582358138,
     "wof:name":"Tasiusaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/673/101870673.geojson
+++ b/data/101/870/673/101870673.geojson
@@ -98,6 +98,9 @@
         "wd:id":"Q682285"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8706967c637956cb8885128ee28fce53",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101870673,
-    "wof:lastmodified":1566638825,
+    "wof:lastmodified":1582358137,
     "wof:name":"Nutaarmiut",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/675/101870675.geojson
+++ b/data/101/870/675/101870675.geojson
@@ -192,8 +192,9 @@
     "qs:type":"buffered point",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes_pg",
-        "quattroshapes"
+        "quattroshapes",
+        "naturalearth",
+        "quattroshapes_pg"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -213,6 +214,11 @@
         "wk:page":"Kullorsuaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9d7ffefd70cf34e6d90f625b476b01a",
     "wof:hierarchy":[
         {
@@ -223,7 +229,7 @@
         }
     ],
     "wof:id":101870675,
-    "wof:lastmodified":1566638824,
+    "wof:lastmodified":1582358137,
     "wof:name":"Kullorsuaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/677/101870677.geojson
+++ b/data/101/870/677/101870677.geojson
@@ -183,8 +183,9 @@
     "qs:type":"buffered point",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "quattroshapes",
         "quattroshapes_pg",
-        "quattroshapes"
+        "naturalearth"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -204,6 +205,11 @@
         "wk:page":"Savissivik"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"a60e79d501efd10e1d09b6778999dda1",
     "wof:hierarchy":[
         {
@@ -214,7 +220,7 @@
         }
     ],
     "wof:id":101870677,
-    "wof:lastmodified":1566638831,
+    "wof:lastmodified":1582358139,
     "wof:name":"Savissivik",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/679/101870679.geojson
+++ b/data/101/870/679/101870679.geojson
@@ -109,6 +109,10 @@
         "wk:page":"Qeqertat"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"960f6222f6b27c340dae6baae64da373",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
         }
     ],
     "wof:id":101870679,
-    "wof:lastmodified":1566638830,
+    "wof:lastmodified":1582358139,
     "wof:name":"Qeqertat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/681/101870681.geojson
+++ b/data/101/870/681/101870681.geojson
@@ -146,6 +146,10 @@
         "qs_pg:id":1044565
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d012dd9deeb936ca87f55c2547ce1ca9",
     "wof:hierarchy":[
         {
@@ -156,7 +160,7 @@
         }
     ],
     "wof:id":101870681,
-    "wof:lastmodified":1566638824,
+    "wof:lastmodified":1582358137,
     "wof:name":"Qeqertarsuaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/683/101870683.geojson
+++ b/data/101/870/683/101870683.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Siorapaluk"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f5ec689c0a66585cd24167692cd3828",
     "wof:hierarchy":[
         {
@@ -128,7 +132,7 @@
         }
     ],
     "wof:id":101870683,
-    "wof:lastmodified":1566638830,
+    "wof:lastmodified":1582358139,
     "wof:name":"Siorapaluk",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/687/101870687.geojson
+++ b/data/101/870/687/101870687.geojson
@@ -285,6 +285,10 @@
         "wk:page":"Qaanaaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9169d7739153650704021ff585cf058a",
     "wof:hierarchy":[
         {
@@ -295,7 +299,7 @@
         }
     ],
     "wof:id":101870687,
-    "wof:lastmodified":1566638825,
+    "wof:lastmodified":1582358137,
     "wof:name":"Qaanaaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/689/101870689.geojson
+++ b/data/101/870/689/101870689.geojson
@@ -109,6 +109,10 @@
         "wk:page":"Moriusaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6991bf45a7f09684931a5da17cc17823",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
         }
     ],
     "wof:id":101870689,
-    "wof:lastmodified":1566638825,
+    "wof:lastmodified":1582358137,
     "wof:name":"Moriusaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/691/101870691.geojson
+++ b/data/101/870/691/101870691.geojson
@@ -214,6 +214,10 @@
         "wk:page":"Nuussuaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth"
+    ],
     "wof:geomhash":"5e2a14acb4ec45f37ac1496f7f958891",
     "wof:hierarchy":[
         {
@@ -224,7 +228,7 @@
         }
     ],
     "wof:id":101870691,
-    "wof:lastmodified":1566638832,
+    "wof:lastmodified":1582358139,
     "wof:name":"Nuussuaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/695/101870695.geojson
+++ b/data/101/870/695/101870695.geojson
@@ -112,6 +112,10 @@
         "wk:page":"Ukkusissat"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b9278ce3a92904e3bb666d2f59de46ba",
     "wof:hierarchy":[
         {
@@ -122,7 +126,7 @@
         }
     ],
     "wof:id":101870695,
-    "wof:lastmodified":1566638827,
+    "wof:lastmodified":1582358138,
     "wof:name":"Ukkusissat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/697/101870697.geojson
+++ b/data/101/870/697/101870697.geojson
@@ -106,6 +106,10 @@
         "wk:page":"Niaqornat"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6529aa6852f01c1195b2e4cb0f09a352",
     "wof:hierarchy":[
         {
@@ -116,7 +120,7 @@
         }
     ],
     "wof:id":101870697,
-    "wof:lastmodified":1566638831,
+    "wof:lastmodified":1582358139,
     "wof:name":"Niaqornat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/699/101870699.geojson
+++ b/data/101/870/699/101870699.geojson
@@ -124,6 +124,10 @@
         "wk:page":"Qaarsut"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd51b8d31791572e91a760a8b69601d7",
     "wof:hierarchy":[
         {
@@ -134,7 +138,7 @@
         }
     ],
     "wof:id":101870699,
-    "wof:lastmodified":1566638831,
+    "wof:lastmodified":1582358139,
     "wof:name":"Qaarsut",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/701/101870701.geojson
+++ b/data/101/870/701/101870701.geojson
@@ -118,6 +118,10 @@
         "wk:page":"Saqqaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"49ed4a9964c4e4b917cb618ebf374bba",
     "wof:hierarchy":[
         {
@@ -128,7 +132,7 @@
         }
     ],
     "wof:id":101870701,
-    "wof:lastmodified":1566638823,
+    "wof:lastmodified":1582358137,
     "wof:name":"Saqqaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/705/101870705.geojson
+++ b/data/101/870/705/101870705.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q1020079"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1deb4f52290afc5219b87ce08dcc058",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101870705,
-    "wof:lastmodified":1566638828,
+    "wof:lastmodified":1582358138,
     "wof:name":"Oqaatsut",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/707/101870707.geojson
+++ b/data/101/870/707/101870707.geojson
@@ -312,6 +312,10 @@
         "qs_pg:id":421916
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"901b63adb036817ba7541355c7072310",
     "wof:hierarchy":[
         {
@@ -322,7 +326,7 @@
         }
     ],
     "wof:id":101870707,
-    "wof:lastmodified":1566638824,
+    "wof:lastmodified":1582358137,
     "wof:name":"Ilulissat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/709/101870709.geojson
+++ b/data/101/870/709/101870709.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Ilimanaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8b05b7744e173c4818ffe92af4ffc07",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":101870709,
-    "wof:lastmodified":1566638824,
+    "wof:lastmodified":1582358137,
     "wof:name":"Ilimanaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/711/101870711.geojson
+++ b/data/101/870/711/101870711.geojson
@@ -243,6 +243,10 @@
         "wk:page":"Qasigiannguit"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"231ae2dd985cb8e895521a4b6db4fe2e",
     "wof:hierarchy":[
         {
@@ -253,7 +257,7 @@
         }
     ],
     "wof:id":101870711,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Qasigiannguit",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/713/101870713.geojson
+++ b/data/101/870/713/101870713.geojson
@@ -136,6 +136,10 @@
         "wk:page":"Kangaatsiaq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c946d14551bddde1b34ccadea495f21e",
     "wof:hierarchy":[
         {
@@ -146,7 +150,7 @@
         }
     ],
     "wof:id":101870713,
-    "wof:lastmodified":1566638827,
+    "wof:lastmodified":1582358138,
     "wof:name":"Kangaatsiaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/715/101870715.geojson
+++ b/data/101/870/715/101870715.geojson
@@ -112,6 +112,10 @@
         "wk:page":"Niaqornaarsuk"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82fce93b75e3f1a947fadebd5cca7b1b",
     "wof:hierarchy":[
         {
@@ -122,7 +126,7 @@
         }
     ],
     "wof:id":101870715,
-    "wof:lastmodified":1566638828,
+    "wof:lastmodified":1582358138,
     "wof:name":"Niaqornaarsuk",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/717/101870717.geojson
+++ b/data/101/870/717/101870717.geojson
@@ -109,6 +109,10 @@
         "wk:page":"Ikerasaarsuk"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"61014b7773ffa959204ab665a33582b8",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
         }
     ],
     "wof:id":101870717,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Ikerasaarsuk",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/719/101870719.geojson
+++ b/data/101/870/719/101870719.geojson
@@ -106,6 +106,10 @@
         "wk:page":"Iginniarfik"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7031d844b884f5eb919506feecc568bc",
     "wof:hierarchy":[
         {
@@ -116,7 +120,7 @@
         }
     ],
     "wof:id":101870719,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Iginniarfik",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/723/101870723.geojson
+++ b/data/101/870/723/101870723.geojson
@@ -148,6 +148,10 @@
         "wk:page":"Nanortalik"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e619b36b968127c3db76df18ab3b29ca",
     "wof:hierarchy":[
         {
@@ -158,7 +162,7 @@
         }
     ],
     "wof:id":101870723,
-    "wof:lastmodified":1566638828,
+    "wof:lastmodified":1582358138,
     "wof:name":"Nanortalik",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/725/101870725.geojson
+++ b/data/101/870/725/101870725.geojson
@@ -112,6 +112,10 @@
         "wk:page":"Saarloq"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"362f45a9bb75e9d2cd0f9f92dc1296bb",
     "wof:hierarchy":[
         {
@@ -122,7 +126,7 @@
         }
     ],
     "wof:id":101870725,
-    "wof:lastmodified":1566638827,
+    "wof:lastmodified":1582358138,
     "wof:name":"Saarloq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/729/101870729.geojson
+++ b/data/101/870/729/101870729.geojson
@@ -107,6 +107,9 @@
         "wd:id":"Q2337295"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f6b2cda217db56d5a2d8f26b059bc06",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101870729,
-    "wof:lastmodified":1566638833,
+    "wof:lastmodified":1582358139,
     "wof:name":"Kitsissuarsuit",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/731/101870731.geojson
+++ b/data/101/870/731/101870731.geojson
@@ -112,6 +112,10 @@
         "wk:page":"Ikerasak"
     },
     "wof:country":"GL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a5c35545f97d1d612ef0785505c79c2c",
     "wof:hierarchy":[
         {
@@ -122,7 +126,7 @@
         }
     ],
     "wof:id":101870731,
-    "wof:lastmodified":1566638824,
+    "wof:lastmodified":1582358137,
     "wof:name":"Ikerasak",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/856/332/17/85633217.geojson
+++ b/data/856/332/17/85633217.geojson
@@ -880,6 +880,7 @@
     "qs:source":"EuroGlobalMap",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes",
         "naturalearth"
     ],
@@ -933,6 +934,11 @@
     },
     "wof:country":"GL",
     "wof:country_alpha3":"GRL",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "quattroshapes",
+        "naturalearth"
+    ],
     "wof:geomhash":"7861b5cc81631b72cbc04c2e1222e009",
     "wof:hierarchy":[
         {
@@ -948,7 +954,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1566638807,
+    "wof:lastmodified":1582358133,
     "wof:name":"Greenland",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/332/17/85633217.geojson
+++ b/data/856/332/17/85633217.geojson
@@ -881,8 +881,7 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "naturalearth",
-        "quattroshapes",
-        "naturalearth"
+        "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -954,7 +953,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1582358133,
+    "wof:lastmodified":1583239405,
     "wof:name":"Greenland",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.