### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/101/870/551/101870551.geojson
+++ b/data/101/870/551/101870551.geojson
@@ -74,6 +74,9 @@
     "name:swe_x_preferred":[
         "Eqalugaarsuit"
     ],
+    "name:ukr_x_preferred":[
+        "\u0415\u043a\u0430\u043b\u0443\u0433\u0430\u0430\u0440\u0441\u0443\u0456\u0442"
+    ],
     "qs:a0":"Kalaallit Nunaat#Gr\u00f8nland",
     "qs:a1":"*Kommune Kujalleq",
     "qs:a1r":"0",
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":101870551,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921777,
     "wof:name":"Eqalugaarsuit",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/557/101870557.geojson
+++ b/data/101/870/557/101870557.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0642\u0627\u0633\u064a\u0627\u0631\u0633\u0648\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0627\u0633\u064a\u0627\u0631\u0633\u0648\u0643"
+    ],
     "name:cat_x_preferred":[
         "Qassiarsuk"
     ],
@@ -50,6 +53,9 @@
     ],
     "name:ita_x_preferred":[
         "Qassiarsuk"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30c3\u30b7\u30a2\u30fc\u30b9\u30c3\u30af"
     ],
     "name:kal_x_preferred":[
         "Qassiarsuk"
@@ -83,6 +89,9 @@
     ],
     "name:und_x_variant":[
         "Kagssiarssuk"
+    ],
+    "name:vie_x_preferred":[
+        "Qassiarsuk"
     ],
     "qs:a0":"Kalaallit Nunaat#Gr\u00f8nland",
     "qs:a1":"*Kommune Kujalleq",
@@ -130,7 +139,7 @@
         }
     ],
     "wof:id":101870557,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921780,
     "wof:name":"Qassiarsuk",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/561/101870561.geojson
+++ b/data/101/870/561/101870561.geojson
@@ -24,10 +24,13 @@
     "name:ara_x_preferred":[
         "\u0646\u0627\u0631\u0633\u0627\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0627\u0631\u0633\u0627\u0643"
+    ],
     "name:ast_x_preferred":[
         "Narsaq"
     ],
-    "name:bel_x_variant":[
+    "name:bel_x_preferred":[
         "\u041d\u0430\u0440\u0441\u0430\u043a"
     ],
     "name:cat_x_preferred":[
@@ -111,6 +114,9 @@
     "name:swe_x_preferred":[
         "Narsaq"
     ],
+    "name:tur_x_preferred":[
+        "Narsaq"
+    ],
     "name:ukr_x_preferred":[
         "\u041d\u0430\u0440\u0441\u0430\u043a"
     ],
@@ -174,7 +180,7 @@
         }
     ],
     "wof:id":101870561,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921779,
     "wof:name":"Narsaq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/563/101870563.geojson
+++ b/data/101/870/563/101870563.geojson
@@ -39,6 +39,9 @@
     "name:fra_x_preferred":[
         "Igaliku"
     ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d9\u05d2\u05dc\u05d9\u05e7\u05d5"
+    ],
     "name:iku_x_preferred":[
         "\u1403\u1490\u14d5\u146f"
     ],
@@ -83,6 +86,9 @@
     ],
     "name:und_x_variant":[
         "Igaliko"
+    ],
+    "name:zho_x_preferred":[
+        "\u4f0a\u594e\u5229\u5e93"
     ],
     "qs:a0":"Kalaallit Nunaat#Gr\u00f8nland",
     "qs:a1":"*Kommune Kujalleq",
@@ -132,7 +138,7 @@
         }
     ],
     "wof:id":101870563,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921795,
     "wof:name":"Igaliku",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/565/101870565.geojson
+++ b/data/101/870/565/101870565.geojson
@@ -21,7 +21,13 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ang_x_preferred":[
+        "Iulianehopa"
+    ],
     "name:ara_x_preferred":[
+        "\u0643\u0627\u0643\u0648\u0631\u062a\u0648\u0643"
+    ],
+    "name:arz_x_preferred":[
         "\u0643\u0627\u0643\u0648\u0631\u062a\u0648\u0643"
     ],
     "name:ast_x_preferred":[
@@ -31,7 +37,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u043a\u0430\u0440\u0442\u043e\u043a"
     ],
     "name:bel_x_variant":[
-        "\u041a\u0430\u043a\u043e\u0440\u0442\u0430\u043a"
+        "\u041a\u0430\u043a\u043e\u0440\u0442\u0430\u043a",
+        "\u041a\u0430\u043a\u0430\u0440\u0442\u043e\u043a"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u0995\u09cb\u09b0\u09a4\u0995"
@@ -43,6 +50,9 @@
         "Qaqortoq"
     ],
     "name:ces_x_preferred":[
+        "Qaqortoq"
+    ],
+    "name:cor_x_preferred":[
         "Qaqortoq"
     ],
     "name:dan_x_preferred":[
@@ -159,11 +169,17 @@
     "name:swe_x_preferred":[
         "Qaqortoq"
     ],
+    "name:tur_x_preferred":[
+        "Qaqortoq"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0430\u043a\u043e\u0440\u0442\u043e\u043a"
     ],
     "name:und_x_variant":[
         "Julianehaab"
+    ],
+    "name:urd_x_preferred":[
+        "\u0642\u0627\u0642\u0648\u0631\u062a\u0648\u0642"
     ],
     "name:vie_x_preferred":[
         "Qaqortoq"
@@ -317,7 +333,7 @@
         }
     ],
     "wof:id":101870565,
-    "wof:lastmodified":1636502626,
+    "wof:lastmodified":1690921796,
     "wof:name":"Qaqortoq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/569/101870569.geojson
+++ b/data/101/870/569/101870569.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:aze_x_preferred":[
+        "Alluitsup-Paa"
+    ],
     "name:cat_x_preferred":[
         "Alluitsup Paa"
     ],
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":101870569,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921777,
     "wof:name":"Alluitsup Paa",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/571/101870571.geojson
+++ b/data/101/870/571/101870571.geojson
@@ -27,6 +27,9 @@
     "name:ben_x_preferred":[
         "\u09a4\u09be\u09b8\u09bf\u0989\u09b8\u09be\u0995"
     ],
+    "name:cat_x_preferred":[
+        "Tasiusaq"
+    ],
     "name:ces_x_preferred":[
         "Tasiusaq"
     ],
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":101870571,
-    "wof:lastmodified":1636502627,
+    "wof:lastmodified":1690921805,
     "wof:name":"Tasiusaq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/575/101870575.geojson
+++ b/data/101/870/575/101870575.geojson
@@ -21,6 +21,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0646\u0627\u0631\u0633\u0627\u0643 \u0643\u0648\u062c\u0627\u0644\u0643"
+    ],
+    "name:bar_x_preferred":[
+        "Narsarmijit"
+    ],
     "name:cat_x_preferred":[
         "Narsarmijit"
     ],
@@ -39,10 +45,16 @@
     "name:deu_x_preferred":[
         "Friedrichstal"
     ],
+    "name:deu_x_variant":[
+        "Narsarmijit"
+    ],
     "name:eng_x_preferred":[
         "Narsaq"
     ],
     "name:eng_x_variant":[
+        "Narsarmijit"
+    ],
+    "name:fin_x_preferred":[
         "Narsarmijit"
     ],
     "name:fra_x_preferred":[
@@ -63,8 +75,14 @@
     "name:nld_x_preferred":[
         "Narsarmijit"
     ],
+    "name:nno_x_preferred":[
+        "Narsarmijit"
+    ],
     "name:nob_x_preferred":[
         "Narsamijit"
+    ],
+    "name:nob_x_variant":[
+        "Narsarmijit"
     ],
     "name:nor_x_preferred":[
         "Narsarmijit"
@@ -132,7 +150,7 @@
         }
     ],
     "wof:id":101870575,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921791,
     "wof:name":"Narsarmijit",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/579/101870579.geojson
+++ b/data/101/870/579/101870579.geojson
@@ -78,6 +78,9 @@
     "name:hun_x_preferred":[
         "Kulusuk"
     ],
+    "name:ind_x_preferred":[
+        "Kulusuk"
+    ],
     "name:isl_x_preferred":[
         "Kulusuk"
     ],
@@ -280,7 +283,7 @@
         }
     ],
     "wof:id":101870579,
-    "wof:lastmodified":1636502627,
+    "wof:lastmodified":1690921806,
     "wof:name":"Kulusuk",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/581/101870581.geojson
+++ b/data/101/870/581/101870581.geojson
@@ -20,6 +20,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:arz_x_preferred":[
+        "\u0627\u0643\u062a\u0627\u062a\u064a\u0642"
+    ],
     "name:ces_x_preferred":[
         "Ikkatteq"
     ],
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101870581,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921790,
     "wof:name":"Ikkatteq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/583/101870583.geojson
+++ b/data/101/870/583/101870583.geojson
@@ -24,8 +24,17 @@
     "name:ara_x_preferred":[
         "\u062a\u0627\u0633\u064a\u0644\u0627\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0627\u0633\u064a\u0644\u0627\u0643"
+    ],
+    "name:ast_x_preferred":[
+        "Tasiilaq"
+    ],
     "name:bar_x_preferred":[
         "Tasiilaq"
+    ],
+    "name:bel_x_preferred":[
+        "\u0410\u043d\u0433\u043c\u0430\u0433\u0441\u0430\u043b\u0456\u043a"
     ],
     "name:ben_x_preferred":[
         "\u09a4\u09be\u09b8\u09bf\u09b2\u09be\u0995"
@@ -75,6 +84,9 @@
     "name:hye_x_preferred":[
         "\u054f\u0561\u057d\u056b\u056b\u056c\u0561\u0584"
     ],
+    "name:ind_x_preferred":[
+        "Tasiilaq"
+    ],
     "name:isl_x_preferred":[
         "Tasiilaq"
     ],
@@ -98,6 +110,9 @@
     ],
     "name:lit_x_preferred":[
         "Tasilakas"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0422\u0430\u0441\u0438\u0438\u043b\u0430\u043a"
     ],
     "name:mkd_x_preferred":[
         "\u0422\u0430\u0441\u0438\u043b\u0430\u043a"
@@ -126,6 +141,9 @@
     "name:swe_x_preferred":[
         "Tasiilaq"
     ],
+    "name:tur_x_preferred":[
+        "Tasiilaq"
+    ],
     "name:ukr_x_preferred":[
         "\u0422\u0430\u0441\u0456\u0456\u043b\u0430\u043a"
     ],
@@ -137,6 +155,9 @@
     ],
     "name:vie_x_preferred":[
         "Tasiilaq"
+    ],
+    "name:yue_x_preferred":[
+        "\u5854\u65af\u62c9\u514b"
     ],
     "name:zho_x_preferred":[
         "\u5b89\u99ac\u8d6b\u590f\u5229\u514b"
@@ -284,7 +305,7 @@
         }
     ],
     "wof:id":101870583,
-    "wof:lastmodified":1636502627,
+    "wof:lastmodified":1690921807,
     "wof:name":"Tasiilaq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/587/101870587.geojson
+++ b/data/101/870/587/101870587.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u0643\u064a\u0631\u062a\u0627\u0631\u0633\u0648\u0627\u062a\u0633\u064a\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0643\u064a\u0631\u062a\u0627\u0631\u0633\u0648\u0627\u062a\u0633\u064a\u0627\u062a"
+    ],
     "name:cat_x_preferred":[
         "Qeqertarsuatsiaat"
     ],
@@ -45,17 +48,32 @@
     "name:eng_x_preferred":[
         "Qeqertarsuatsiaat"
     ],
+    "name:est_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
+    "name:fin_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
+    "name:fit_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
     "name:fra_x_preferred":[
         "Qeqertarsuatsiaat"
     ],
     "name:ita_x_preferred":[
         "Qeqertarsuatsiaat"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d5\u30a3\u30b9\u30b1\u30cd\u30bb\u30c3\u30c8"
+    ],
     "name:kal_x_preferred":[
         "Qeqertarsuatsiaat"
     ],
     "name:kat_x_preferred":[
         "\u10d9\u10d4\u10d9\u10d4\u10e0\u10e2\u10d0\u10e0\u10e1\u10e3\u10d0\u10e2\u10e1\u10d8\u10d0\u10d0\u10e2\u10d8"
+    ],
+    "name:mhr_x_preferred":[
+        "\u041a\u0435\u043a\u0435\u0440\u0442\u0430\u0440\u0441\u0443\u0430\u0442\u0441\u0438\u0430\u0430\u0442"
     ],
     "name:nld_x_preferred":[
         "Qeqertarsuatsiaat"
@@ -72,8 +90,35 @@
     "name:por_x_preferred":[
         "Qeqertarsuatsiaat"
     ],
+    "name:rmf_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u0435\u043a\u0435\u0440\u0442\u0430\u0440\u0441\u0443\u0430\u0442\u0441\u0438\u0430\u0430\u0442"
+    ],
+    "name:sjd_x_preferred":[
+        "\u041a\u0435\u043a\u0435\u0440\u0442\u0430\u0440\u0441\u0443\u0430\u0442\u0441\u0438\u0430\u0430\u0442"
+    ],
+    "name:sje_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
+    "name:sju_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
+    "name:sma_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
+    "name:sme_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
+    "name:smj_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
+    "name:smn_x_preferred":[
+        "Qeqertarsuatsiaat"
+    ],
+    "name:sms_x_preferred":[
+        "Qeqertarsuatsiaat"
     ],
     "name:spa_x_preferred":[
         "Qeqertarsuatsiaat"
@@ -132,7 +177,7 @@
         }
     ],
     "wof:id":101870587,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921792,
     "wof:name":"Qeqertarsuatsiaat",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/589/101870589.geojson
+++ b/data/101/870/589/101870589.geojson
@@ -27,11 +27,17 @@
     "name:ara_x_preferred":[
         "\u0625\u064a\u062a\u0648\u0643\u0648\u0631\u062a\u064a\u0631\u0645\u0627\u064a\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u064a\u062a\u0648\u0643\u0648\u0631\u062a\u064a\u0631\u0645\u0627\u064a\u062a"
+    ],
     "name:ast_x_preferred":[
         "Ittoqqortoormiit"
     ],
     "name:bak_x_preferred":[
         "\u0418\u043b\u043b\u043e\u043a\u043a\u043e\u0440\u0442\u043e\u043e\u0440\u043c\u0438\u0443\u0442"
+    ],
+    "name:bel_x_preferred":[
+        "\u0406\u043b\u0430\u043a\u0430\u0440\u0442\u0430\u0430\u0440\u043c\u0456\u0443\u0442"
     ],
     "name:cat_x_preferred":[
         "Ittoqqortoormiit"
@@ -48,7 +54,13 @@
     "name:deu_x_preferred":[
         "Ittoqqortoormiit"
     ],
+    "name:ell_x_preferred":[
+        "\u0399\u03c4\u03bf\u03ba\u03bf\u03c1\u03c4\u03cc\u03c1\u03bc\u03b9\u03c4"
+    ],
     "name:eng_x_preferred":[
+        "Ittoqqortoormiit"
+    ],
+    "name:eus_x_preferred":[
         "Ittoqqortoormiit"
     ],
     "name:fao_x_preferred":[
@@ -70,6 +82,9 @@
         "Illoqqortoormiut"
     ],
     "name:glg_x_preferred":[
+        "Ittoqqortoormiit"
+    ],
+    "name:hrv_x_preferred":[
         "Ittoqqortoormiit"
     ],
     "name:hun_x_preferred":[
@@ -109,6 +124,9 @@
         "Itokortormitas"
     ],
     "name:nld_x_preferred":[
+        "Ittoqqortoormiit"
+    ],
+    "name:nno_x_preferred":[
         "Ittoqqortoormiit"
     ],
     "name:nob_x_preferred":[
@@ -152,6 +170,9 @@
     ],
     "name:und_x_variant":[
         "Scoresby Sound"
+    ],
+    "name:yue_x_preferred":[
+        "\u65af\u79d1\u65af\u6bd4\u9b06"
     ],
     "name:zho_x_preferred":[
         "\u65af\u79d1\u65af\u6bd4\u9b06"
@@ -207,7 +228,7 @@
         }
     ],
     "wof:id":101870589,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921792,
     "wof:name":"Illoqqortoormiut",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/591/101870591.geojson
+++ b/data/101/870/591/101870591.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0627\u062a\u0631\u0627\u062c\u064a\u0641\u064a\u062a"
+    ],
     "name:ces_x_preferred":[
         "Itterajivit"
     ],
@@ -28,6 +31,9 @@
         "Kap Hope"
     ],
     "name:dan_x_variant":[
+        "Itterajivit"
+    ],
+    "name:deu_x_preferred":[
         "Itterajivit"
     ],
     "name:eng_x_preferred":[
@@ -99,7 +105,7 @@
         }
     ],
     "wof:id":101870591,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921796,
     "wof:name":"Ittaajimmiit",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/593/101870593.geojson
+++ b/data/101/870/593/101870593.geojson
@@ -20,6 +20,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0646\u0627\u0631\u062a\u064a\u0643"
+    ],
     "name:bre_x_preferred":[
         "Uunarteq"
     ],
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101870593,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921778,
     "wof:name":"Uunarteq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/597/101870597.geojson
+++ b/data/101/870/597/101870597.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0646\u064a\u062a\u0633\u0648\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0646\u064a\u062a\u0633\u0648\u0643"
+    ],
     "name:ast_x_preferred":[
         "Maniitsoq"
     ],
@@ -31,7 +34,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u043d\u0456\u0442\u0441\u043e\u043a"
     ],
     "name:bel_x_variant":[
-        "\u041c\u0430\u043d\u0456\u0456\u0442\u0441\u0430\u043a"
+        "\u041c\u0430\u043d\u0456\u0456\u0442\u0441\u0430\u043a",
+        "\u041c\u0430\u043d\u0456\u0442\u0441\u043e\u043a"
     ],
     "name:cat_x_preferred":[
         "Maniitsoq"
@@ -123,6 +127,9 @@
     "name:swe_x_preferred":[
         "Maniitsoq"
     ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u043d\u0456\u0457\u0442\u0441\u043e\u043a"
+    ],
     "name:und_x_variant":[
         "Manitsoq"
     ],
@@ -180,7 +187,7 @@
         }
     ],
     "wof:id":101870597,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921795,
     "wof:name":"Maniitsoq",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/599/101870599.geojson
+++ b/data/101/870/599/101870599.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0646\u062c\u0627\u0645\u064a\u0648\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0646\u062c\u0627\u0645\u064a\u0648\u062a"
+    ],
     "name:cat_x_preferred":[
         "Kangaamiut"
     ],
@@ -43,6 +46,9 @@
         "Kangaamiut"
     ],
     "name:fra_x_preferred":[
+        "Kangaamiut"
+    ],
+    "name:ind_x_preferred":[
         "Kangaamiut"
     ],
     "name:ita_x_preferred":[
@@ -132,7 +138,7 @@
         }
     ],
     "wof:id":101870599,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921794,
     "wof:name":"Kangaamiut",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/601/101870601.geojson
+++ b/data/101/870/601/101870601.geojson
@@ -27,6 +27,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u0633\u064a\u0645\u064a\u0648\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0633\u064a\u0645\u064a\u0648\u062a"
+    ],
     "name:ast_x_preferred":[
         "Sisimiut"
     ],
@@ -34,7 +37,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0456\u0441\u0456\u043c\u0456\u045e\u0442"
     ],
     "name:bel_x_variant":[
-        "\u0421\u044b\u0441\u044b\u043c\u0456\u044e\u0442"
+        "\u0421\u044b\u0441\u044b\u043c\u0456\u044e\u0442",
+        "\u0421\u0456\u0441\u0456\u043c\u0456\u045e\u0442"
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09bf\u09b8\u09bf\u09ae\u09bf\u0989\u09a4"
@@ -46,6 +50,9 @@
         "Sisimiut"
     ],
     "name:ces_x_preferred":[
+        "Sisimiut"
+    ],
+    "name:cor_x_preferred":[
         "Sisimiut"
     ],
     "name:dan_x_preferred":[
@@ -158,6 +165,9 @@
     ],
     "name:sgs_x_preferred":[
         "Sisimiuts"
+    ],
+    "name:slk_x_preferred":[
+        "Sisimiut"
     ],
     "name:spa_x_preferred":[
         "Sisimiut"
@@ -332,7 +342,7 @@
         }
     ],
     "wof:id":101870601,
-    "wof:lastmodified":1636502626,
+    "wof:lastmodified":1690921802,
     "wof:name":"Sisimiut",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/603/101870603.geojson
+++ b/data/101/870/603/101870603.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0631\u0641\u0627\u0646\u062c\u0648\u064a\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0631\u0641\u0627\u0646\u062c\u0648\u064a\u062a"
+    ],
     "name:ast_x_preferred":[
         "Sarfannguit"
     ],
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101870603,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921787,
     "wof:name":"Sarfannguit",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/605/101870605.geojson
+++ b/data/101/870/605/101870605.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0625\u0644\u064a\u0644\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u064a\u0644\u0643"
+    ],
     "name:bar_x_preferred":[
         "Itilleq"
     ],
@@ -84,6 +87,9 @@
     "name:rus_x_preferred":[
         "\u0418\u0442\u0438\u043b\u043b\u0435\u043a"
     ],
+    "name:sme_x_preferred":[
+        "Itilleq"
+    ],
     "name:spa_x_preferred":[
         "Itilleq"
     ],
@@ -143,7 +149,7 @@
         }
     ],
     "wof:id":101870605,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921786,
     "wof:name":"Itilleq",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/609/101870609.geojson
+++ b/data/101/870/609/101870609.geojson
@@ -63,6 +63,9 @@
     "name:eng_x_preferred":[
         "Kangerlussuaq"
     ],
+    "name:est_x_preferred":[
+        "Kangerlussuaq"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0627\u0646\u06af\u0631\u0644\u0648\u0633\u0648\u0627\u0642"
     ],
@@ -101,6 +104,9 @@
     ],
     "name:kom_x_preferred":[
         "\u041a\u0430\u043d\u0433\u0435\u0440\u043b\u0443\u0441\u0441\u0443\u0430\u043a"
+    ],
+    "name:kor_x_preferred":[
+        "\uce78\uac8c\ub97c\ub8e8\uc218\uc545"
     ],
     "name:nld_x_preferred":[
         "Kangerlussuaq"
@@ -283,7 +289,7 @@
         }
     ],
     "wof:id":101870609,
-    "wof:lastmodified":1636502627,
+    "wof:lastmodified":1690921804,
     "wof:name":"Kangerlussuaq",
     "wof:parent_id":85684717,
     "wof:placetype":"locality",

--- a/data/101/870/611/101870611.geojson
+++ b/data/101/870/611/101870611.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u0631\u0645\u064a\u0644\u064a\u062c\u0627\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0631\u0645\u064a\u0644\u064a\u062c\u0627\u0643"
+    ],
     "name:cat_x_preferred":[
         "Sermiligaaq"
     ],
@@ -43,6 +46,9 @@
         "Sermiligaaq"
     ],
     "name:fra_x_preferred":[
+        "Sermiligaaq"
+    ],
+    "name:ind_x_preferred":[
         "Sermiligaaq"
     ],
     "name:ita_x_preferred":[
@@ -77,6 +83,9 @@
     ],
     "name:swe_x_preferred":[
         "Sermiligaaq"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0421\u0435\u0440\u043c\u0456\u043b\u0456\u0491\u0430\u0430\u043a"
     ],
     "name:und_x_variant":[
         "Utorqarmiut"
@@ -129,7 +138,7 @@
         }
     ],
     "wof:id":101870611,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921786,
     "wof:name":"Sermiligaaq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/617/101870617.geojson
+++ b/data/101/870/617/101870617.geojson
@@ -39,6 +39,12 @@
     "name:eng_x_preferred":[
         "Tiniteqilaaq"
     ],
+    "name:eng_x_variant":[
+        "Tiilerilaaq"
+    ],
+    "name:fin_x_preferred":[
+        "Tiilerilaaq"
+    ],
     "name:fra_x_preferred":[
         "Tiniteqilaaq"
     ],
@@ -51,8 +57,14 @@
     "name:nld_x_preferred":[
         "Tiniteqilaaq"
     ],
+    "name:nno_x_preferred":[
+        "Tiilerilaaq"
+    ],
     "name:nob_x_preferred":[
         "Tiniteqilaaq"
+    ],
+    "name:nob_x_variant":[
+        "Tiilerilaaq"
     ],
     "name:nor_x_preferred":[
         "Tiniteqilaaq"
@@ -123,7 +135,7 @@
         }
     ],
     "wof:id":101870617,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921782,
     "wof:name":"Tiniteqilaaq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/619/101870619.geojson
+++ b/data/101/870/619/101870619.geojson
@@ -39,6 +39,12 @@
     "name:eng_x_preferred":[
         "Isortoq"
     ],
+    "name:eng_x_variant":[
+        "Isertoq"
+    ],
+    "name:fin_x_preferred":[
+        "Isertoq"
+    ],
     "name:fra_x_preferred":[
         "Isortoq"
     ],
@@ -60,8 +66,14 @@
     "name:nld_x_preferred":[
         "Isortoq"
     ],
+    "name:nno_x_preferred":[
+        "Isertoq"
+    ],
     "name:nob_x_preferred":[
         "Isortoq"
+    ],
+    "name:nob_x_variant":[
+        "Isertoq"
     ],
     "name:nor_x_preferred":[
         "Isortoq"
@@ -132,7 +144,7 @@
         }
     ],
     "wof:id":101870619,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921783,
     "wof:name":"Isortoq",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/623/101870623.geojson
+++ b/data/101/870/623/101870623.geojson
@@ -77,6 +77,9 @@
     "name:ben_x_preferred":[
         "\u09a8\u09c1\u0989\u0995"
     ],
+    "name:ben_x_variant":[
+        "\u09a8\u09c1\u0995"
+    ],
     "name:bis_x_preferred":[
         "Nuuk"
     ],
@@ -119,11 +122,17 @@
     "name:chr_x_preferred":[
         "Nuuk"
     ],
+    "name:chu_x_preferred":[
+        "\u041d\u043e\u0443\u043a\u044a"
+    ],
     "name:chv_x_preferred":[
         "\u041d\u0443\u0443\u043a"
     ],
     "name:chy_x_preferred":[
         "Nuuk"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0646\u0648\u0648\u06a9"
     ],
     "name:cos_x_preferred":[
         "Nuuk"
@@ -280,6 +289,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e0\u05d5\u05d0\u05d5\u05e7"
+    ],
+    "name:heb_x_variant":[
+        "\u05e0\u05d5\u05e7"
     ],
     "name:her_x_preferred":[
         "Nuuk"
@@ -446,6 +458,9 @@
     "name:lzz_x_preferred":[
         "Nuuk"
     ],
+    "name:mal_x_preferred":[
+        "\u0d28\u0d4d\u0d2f\u0d42\u0d15\u0d4d"
+    ],
     "name:mar_x_preferred":[
         "\u0928\u0942\u0915"
     ],
@@ -472,6 +487,9 @@
     ],
     "name:mwl_x_preferred":[
         "Nuuk"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0646\u0648\u06a9"
     ],
     "name:nah_x_preferred":[
         "Nuuk"
@@ -647,6 +665,9 @@
     "name:sme_x_preferred":[
         "Nuuk"
     ],
+    "name:smn_x_preferred":[
+        "Nuuk"
+    ],
     "name:smo_x_preferred":[
         "Nuuk"
     ],
@@ -736,6 +757,9 @@
     ],
     "name:tur_x_preferred":[
         "Nuuk"
+    ],
+    "name:udm_x_preferred":[
+        "\u041d\u0443\u0443\u043a"
     ],
     "name:ukr_x_preferred":[
         "\u041d\u0443\u0443\u043a"
@@ -958,7 +982,7 @@
         }
     ],
     "wof:id":101870623,
-    "wof:lastmodified":1607390879,
+    "wof:lastmodified":1690921798,
     "wof:megacity":0,
     "wof:name":"Nuuk",
     "wof:parent_id":85684729,

--- a/data/101/870/625/101870625.geojson
+++ b/data/101/870/625/101870625.geojson
@@ -24,8 +24,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0645\u064a\u0648\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0645\u064a\u0648\u062a"
+    ],
     "name:ast_x_preferred":[
         "Paamiut"
+    ],
+    "name:aze_x_preferred":[
+        "Pamiut"
     ],
     "name:bel_x_variant":[
         "\u041f\u0430\u0430\u043c\u0456\u044e\u0442"
@@ -147,6 +153,9 @@
     "name:swe_x_preferred":[
         "Paamiut"
     ],
+    "name:tur_x_preferred":[
+        "Paamiut"
+    ],
     "name:ukr_x_preferred":[
         "\u041f\u0430\u0430\u043c\u0456\u0443\u0442"
     ],
@@ -155,6 +164,9 @@
     ],
     "name:vie_x_preferred":[
         "Paamiut"
+    ],
+    "name:yue_x_preferred":[
+        "\u5e15\u7c73\u5c24\u7279"
     ],
     "name:zho_x_preferred":[
         "\u5e15\u7f2a\u7279"
@@ -302,7 +314,7 @@
         }
     ],
     "wof:id":101870625,
-    "wof:lastmodified":1636502626,
+    "wof:lastmodified":1690921796,
     "wof:name":"Paamiut",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/629/101870629.geojson
+++ b/data/101/870/629/101870629.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0625\u064a\u0641\u064a\u062a\u0648\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u064a\u0641\u064a\u062a\u0648\u062a"
+    ],
     "name:ast_x_preferred":[
         "Ivittuut"
     ],
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101870629,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921785,
     "wof:name":"Ivittuut",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/101/870/637/101870637.geojson
+++ b/data/101/870/637/101870637.geojson
@@ -60,11 +60,17 @@
     "name:iku_x_preferred":[
         "\u140a\u146f\u14d0\u14c8\u1585"
     ],
+    "name:ind_x_preferred":[
+        "Akunnaaq"
+    ],
     "name:ita_x_preferred":[
         "Akunnaaq"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30af\u30ca\u30fc\u30af"
+    ],
+    "name:kal_x_preferred":[
+        "Akunnaaq"
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10d9\u10e3\u10dc\u10d0\u10d0\u10d9\u10d8"
@@ -144,7 +150,7 @@
         }
     ],
     "wof:id":101870637,
-    "wof:lastmodified":1582358139,
+    "wof:lastmodified":1690921801,
     "wof:name":"Akunnaaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/639/101870639.geojson
+++ b/data/101/870/639/101870639.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0622\u0633\u064a\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0633\u064a\u0627\u062a"
+    ],
     "name:ast_x_preferred":[
         "Aasiaat"
     ],
@@ -66,6 +69,9 @@
     "name:fin_x_preferred":[
         "Aasiaat"
     ],
+    "name:fit_x_preferred":[
+        "Aasiaat"
+    ],
     "name:fra_x_preferred":[
         "Aasiaat"
     ],
@@ -86,6 +92,9 @@
     ],
     "name:iku_x_preferred":[
         "\u140b\u14ef\u140b\u1466"
+    ],
+    "name:ind_x_preferred":[
+        "Aasiaat"
     ],
     "name:isl_x_preferred":[
         "Aasiaat"
@@ -108,8 +117,14 @@
     "name:kor_x_preferred":[
         "\uc544\uc2dc\uc544\ud2b8"
     ],
+    "name:kor_x_variant":[
+        "\uc544\uc2dc\uc557"
+    ],
     "name:lit_x_preferred":[
         "Osiotas"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0410\u0430\u0441\u0438\u0430\u0430\u0442"
     ],
     "name:mkd_x_preferred":[
         "\u0410\u0441\u0438\u0458\u0430\u0442"
@@ -135,6 +150,9 @@
     "name:por_x_preferred":[
         "Aasiaat"
     ],
+    "name:rmf_x_preferred":[
+        "Aasiaat"
+    ],
     "name:ron_x_preferred":[
         "Aasiaat"
     ],
@@ -150,7 +168,31 @@
     "name:sgs_x_preferred":[
         "Uosiuots"
     ],
+    "name:sjd_x_preferred":[
+        "\u0410\u0430\u0441\u0438\u0430\u0430\u0442"
+    ],
+    "name:sje_x_preferred":[
+        "Aasiaat"
+    ],
+    "name:sju_x_preferred":[
+        "Aasiaat"
+    ],
     "name:slk_x_preferred":[
+        "Aasiaat"
+    ],
+    "name:sma_x_preferred":[
+        "Aasiaat"
+    ],
+    "name:sme_x_preferred":[
+        "Aasiaat"
+    ],
+    "name:smj_x_preferred":[
+        "Aasiaat"
+    ],
+    "name:smn_x_preferred":[
+        "Aasiaat"
+    ],
+    "name:sms_x_preferred":[
         "Aasiaat"
     ],
     "name:spa_x_preferred":[
@@ -160,6 +202,9 @@
         "\u0410\u0441\u0438\u0458\u0430\u0442"
     ],
     "name:swe_x_preferred":[
+        "Aasiaat"
+    ],
+    "name:tur_x_preferred":[
         "Aasiaat"
     ],
     "name:ukr_x_preferred":[
@@ -173,6 +218,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4e9e\u897f\u4e9e\u7279"
+    ],
+    "name:zho_x_variant":[
+        "\u963f\u897f\u4e9a\u7279"
     ],
     "qs:a0":"Kalaallit Nunaat#Gr\u00f8nland",
     "qs:a1":"*Qaasuitsup Kommunia",
@@ -225,7 +273,7 @@
         }
     ],
     "wof:id":101870639,
-    "wof:lastmodified":1582358139,
+    "wof:lastmodified":1690921802,
     "wof:name":"Aasiaat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/641/101870641.geojson
+++ b/data/101/870/641/101870641.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0642\u0642\u0631\u062a\u0627\u0642"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0642\u0631\u062a\u0627\u0642"
+    ],
     "name:ceb_x_preferred":[
         "Qeqertaq"
     ],
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101870641,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921799,
     "wof:name":"Qeqertaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/643/101870643.geojson
+++ b/data/101/870/643/101870643.geojson
@@ -24,8 +24,14 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0645\u0627\u0646\u0627\u0642"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0645\u0627\u0646\u0627\u0642"
+    ],
     "name:ast_x_preferred":[
         "Uummannaq"
+    ],
+    "name:bel_x_preferred":[
+        "\u0423\u043c\u0430\u043d\u0430\u043a"
     ],
     "name:bel_x_variant":[
         "\u0423\u045e\u043c\u0430\u043d\u0430\u043a"
@@ -50,6 +56,9 @@
     ],
     "name:epo_x_preferred":[
         "Uummannaq"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u0648\u0645\u0627\u0646\u0627\u06a9"
     ],
     "name:fin_x_preferred":[
         "Uummannaq"
@@ -292,7 +301,7 @@
         }
     ],
     "wof:id":101870643,
-    "wof:lastmodified":1636502625,
+    "wof:lastmodified":1690921782,
     "wof:name":"Uummannaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/651/101870651.geojson
+++ b/data/101/870/651/101870651.geojson
@@ -28,6 +28,9 @@
         "\u0643\u064a\u0643\u064a\u0631\u062a\u0627\u0631\u0633\u0648\u0627\u0643",
         "\u0643\u064a\u0643\u0631\u062a\u0627\u0631\u0633\u0648\u0627\u062c"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0643\u064a\u0631\u062a\u0627\u0631\u0633\u0648\u0627\u0643"
+    ],
     "name:ast_x_preferred":[
         "Qeqertarsuaq"
     ],
@@ -148,6 +151,9 @@
     "name:tur_x_preferred":[
         "Qeqertarsuaq"
     ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0435\u043a\u0435\u0440\u0442\u0430\u0440\u0441\u0443\u0430\u043a"
+    ],
     "name:und_x_variant":[
         "Kekertarsuak"
     ],
@@ -211,7 +217,7 @@
         }
     ],
     "wof:id":101870651,
-    "wof:lastmodified":1636502625,
+    "wof:lastmodified":1690921787,
     "wof:name":"Qeqertarsuaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/653/101870653.geojson
+++ b/data/101/870/653/101870653.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0648\u0631\u0633\u0648\u064a\u062a"
+    ],
     "name:bar_x_preferred":[
         "Illorsuit"
     ],
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101870653,
-    "wof:lastmodified":1582358139,
+    "wof:lastmodified":1690921804,
     "wof:name":"Illorsuit",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/679/101870679.geojson
+++ b/data/101/870/679/101870679.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u0643\u064a\u0631\u062a\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0643\u064a\u0631\u062a\u0627\u062a"
+    ],
     "name:cat_x_preferred":[
         "Qeqertat"
     ],
@@ -71,6 +74,9 @@
     ],
     "name:swe_x_preferred":[
         "Qeqertat"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0435\u043a\u0435\u0440\u0442\u0430\u0442"
     ],
     "name:und_x_variant":[
         "Kekertat"
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":101870679,
-    "wof:lastmodified":1582358139,
+    "wof:lastmodified":1690921799,
     "wof:name":"Qeqertat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/683/101870683.geojson
+++ b/data/101/870/683/101870683.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0633\u064a\u0648\u0631\u0627\u0628\u0627\u0644\u0648\u0643"
+    ],
     "name:ast_x_preferred":[
         "Siorapaluk"
     ],
@@ -84,6 +87,9 @@
     "name:und_x_variant":[
         "Igdluluarssuit"
     ],
+    "name:zho_x_preferred":[
+        "\u8096\u62c9\u5e15\u5362\u514b"
+    ],
     "qs:a0":"Kalaallit Nunaat#Gr\u00f8nland",
     "qs:a1":"*Qaasuitsup Kommunia",
     "qs:a1r":"0",
@@ -132,7 +138,7 @@
         }
     ],
     "wof:id":101870683,
-    "wof:lastmodified":1582358139,
+    "wof:lastmodified":1690921799,
     "wof:name":"Siorapaluk",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/687/101870687.geojson
+++ b/data/101/870/687/101870687.geojson
@@ -24,8 +24,14 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0646\u0627\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0646\u0627\u0643"
+    ],
     "name:ast_x_preferred":[
         "Qaanaaq"
+    ],
+    "name:aze_x_preferred":[
+        "Kaanaak"
     ],
     "name:bel_x_preferred":[
         "\u041a\u0430\u0430\u043d\u0430\u0430\u043a"
@@ -48,6 +54,9 @@
     "name:ckb_x_preferred":[
         "\u06a9\u0627\u0646\u0627\u06a9"
     ],
+    "name:cym_x_preferred":[
+        "Qaanaaq"
+    ],
     "name:dan_x_preferred":[
         "Qaanaaq"
     ],
@@ -56,6 +65,9 @@
     ],
     "name:deu_x_preferred":[
         "Qaanaaq"
+    ],
+    "name:ell_x_preferred":[
+        "\u039a\u03ac\u03b1\u03bd\u03b1\u03b1\u03ba"
     ],
     "name:eng_x_preferred":[
         "Qaanaaq"
@@ -66,6 +78,9 @@
     "name:est_x_preferred":[
         "Qaanaaq"
     ],
+    "name:fas_x_preferred":[
+        "\u0642\u0627\u0622\u0646\u0627\u0642"
+    ],
     "name:fin_x_preferred":[
         "Qaanaaq"
     ],
@@ -73,6 +88,9 @@
         "Qaanaaq"
     ],
     "name:frr_x_preferred":[
+        "Qaanaaq"
+    ],
+    "name:gle_x_preferred":[
         "Qaanaaq"
     ],
     "name:hbs_x_preferred":[
@@ -126,6 +144,9 @@
     "name:nld_x_preferred":[
         "Qaanaaq"
     ],
+    "name:nno_x_preferred":[
+        "Qaanaaq"
+    ],
     "name:nob_x_preferred":[
         "Qaanaaq"
     ],
@@ -153,11 +174,20 @@
     "name:spa_x_preferred":[
         "Qaanaaq"
     ],
+    "name:sqi_x_preferred":[
+        "Qaanaaq"
+    ],
+    "name:srd_x_preferred":[
+        "Qaanaaq"
+    ],
     "name:swe_x_preferred":[
         "Qaanaaq"
     ],
     "name:tur_x_preferred":[
         "Qaanaaq"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0430\u0430\u043d\u0430\u0430\u043a"
     ],
     "name:und_x_variant":[
         "Q\u00e2n\u00e2q"
@@ -314,7 +344,7 @@
         }
     ],
     "wof:id":101870687,
-    "wof:lastmodified":1636502625,
+    "wof:lastmodified":1690921784,
     "wof:name":"Qaanaaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/689/101870689.geojson
+++ b/data/101/870/689/101870689.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0631\u064a\u0633\u0627\u0643"
+    ],
     "name:cat_x_preferred":[
         "Moriusaq"
     ],
@@ -75,6 +78,9 @@
     "name:zho_x_preferred":[
         "\u83ab\u7ea6\u8d5b\u514b"
     ],
+    "name:zho_x_variant":[
+        "\u83ab\u91cc\u4e4c\u8428\u514b"
+    ],
     "qs:a0":"Kalaallit Nunaat#Gr\u00f8nland",
     "qs:a1":"*Qaasuitsup Kommunia",
     "qs:a1r":"0",
@@ -123,7 +129,7 @@
         }
     ],
     "wof:id":101870689,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921784,
     "wof:name":"Moriusaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/691/101870691.geojson
+++ b/data/101/870/691/101870691.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0646\u0648\u0633\u0648\u0627\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0648\u0633\u0648\u0627\u0643"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09c1\u0989\u09b8\u09b8\u09c1\u09df\u09be\u0995"
     ],
@@ -270,7 +273,7 @@
         }
     ],
     "wof:id":101870691,
-    "wof:lastmodified":1636502626,
+    "wof:lastmodified":1690921803,
     "wof:name":"Nuussuaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/695/101870695.geojson
+++ b/data/101/870/695/101870695.geojson
@@ -78,6 +78,9 @@
     "name:und_x_variant":[
         "Uvkusigssat"
     ],
+    "name:zho_x_preferred":[
+        "\u70cf\u5eab\u85a9\u85a9\u7279"
+    ],
     "qs:a0":"Kalaallit Nunaat#Gr\u00f8nland",
     "qs:a1":"*Qaasuitsup Kommunia",
     "qs:a1r":"0",
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101870695,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921789,
     "wof:name":"Ukkusissat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/699/101870699.geojson
+++ b/data/101/870/699/101870699.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0631\u0633\u0648\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0631\u0633\u0648\u062a"
+    ],
     "name:bul_x_preferred":[
         "\u041a\u0430\u0430\u0440\u0441\u0443\u0442"
     ],
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101870699,
-    "wof:lastmodified":1582358139,
+    "wof:lastmodified":1690921801,
     "wof:name":"Qaarsut",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/701/101870701.geojson
+++ b/data/101/870/701/101870701.geojson
@@ -39,8 +39,14 @@
     "name:eng_x_preferred":[
         "Saqqaq"
     ],
+    "name:fin_x_preferred":[
+        "Saqqaq"
+    ],
     "name:fra_x_preferred":[
         "Saqqaq"
+    ],
+    "name:heb_x_preferred":[
+        "\u05ea\u05e8\u05d1\u05d5\u05ea \u05e1\u05d0\u05e7\u05d0\u05e7"
     ],
     "name:iku_x_preferred":[
         "\u14f4\u1585\u1583\u1585"
@@ -83,6 +89,9 @@
     ],
     "name:und_x_variant":[
         "Sarqaq"
+    ],
+    "name:zho_x_preferred":[
+        "\u85a9\u5361\u514b"
     ],
     "qs:a0":"Kalaallit Nunaat#Gr\u00f8nland",
     "qs:a1":"*Qaasuitsup Kommunia",
@@ -132,7 +141,7 @@
         }
     ],
     "wof:id":101870701,
-    "wof:lastmodified":1582358137,
+    "wof:lastmodified":1690921779,
     "wof:name":"Saqqaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/705/101870705.geojson
+++ b/data/101/870/705/101870705.geojson
@@ -21,6 +21,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0623\u0648\u0642\u0627\u062a\u0633\u0648\u062a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0643\u0627\u062a\u0633\u0648\u062a"
+    ],
     "name:cat_x_preferred":[
         "Oqaatsut"
     ],
@@ -40,6 +46,9 @@
         "Oqaatsut"
     ],
     "name:fra_x_preferred":[
+        "Oqaatsut"
+    ],
+    "name:hau_x_preferred":[
         "Oqaatsut"
     ],
     "name:ita_x_preferred":[
@@ -126,7 +135,7 @@
         }
     ],
     "wof:id":101870705,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921793,
     "wof:name":"Oqaatsut",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/707/101870707.geojson
+++ b/data/101/870/707/101870707.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0625\u064a\u0644\u0648\u0644\u064a\u0633\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u064a\u0644\u0648\u0644\u064a\u0633\u0627\u062a"
+    ],
     "name:ast_x_preferred":[
         "Ilulissat"
     ],
@@ -34,7 +37,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u0406\u043b\u0443\u043b\u0456\u0441\u0430\u0442"
     ],
     "name:bel_x_variant":[
-        "\u0406\u043b\u044e\u043b\u0456\u0441\u0430\u0442"
+        "\u0406\u043b\u044e\u043b\u0456\u0441\u0430\u0442",
+        "\u0406\u043b\u0443\u043b\u0456\u0441\u0430\u0442"
     ],
     "name:ben_x_preferred":[
         "\u0987\u09b2\u09c1\u09b2\u09bf\u09b8\u09be\u09a4"
@@ -51,6 +55,9 @@
     "name:ces_x_preferred":[
         "Ilulissat"
     ],
+    "name:cor_x_preferred":[
+        "Ilulissat"
+    ],
     "name:dan_x_preferred":[
         "Ilulissat"
     ],
@@ -62,6 +69,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a0\u03b1\u03b3\u03b5\u03c4\u03ce\u03bd\u03b1\u03c2 \u03ba\u03b1\u03b9 \u03a6\u03b9\u03cc\u03c1\u03b4 \u0399\u03bb\u03bf\u03cd\u03bb\u03b9\u03c3\u03c3\u03b1\u03c4"
+    ],
+    "name:ell_x_variant":[
+        "\u0399\u03bb\u03bf\u03c5\u03bb\u03b9\u03c3\u03ac\u03c4"
     ],
     "name:eng_x_preferred":[
         "Ilulissat"
@@ -84,6 +94,9 @@
     "name:frr_x_preferred":[
         "Ilulissat"
     ],
+    "name:gle_x_preferred":[
+        "Ilulissat"
+    ],
     "name:heb_x_preferred":[
         "\u05d0\u05d9\u05dc\u05d5\u05dc\u05d9\u05e1\u05d0\u05d8"
     ],
@@ -100,6 +113,9 @@
         "Ilulissat"
     ],
     "name:ita_x_preferred":[
+        "Ilulissat"
+    ],
+    "name:jav_x_preferred":[
         "Ilulissat"
     ],
     "name:jpn_x_preferred":[
@@ -125,6 +141,9 @@
     ],
     "name:mkd_x_preferred":[
         "\u0418\u043b\u0443\u043b\u0438\u0441\u0430\u0442"
+    ],
+    "name:msa_x_preferred":[
+        "Ilulissat"
     ],
     "name:nah_x_preferred":[
         "Ilulissat"
@@ -182,6 +201,9 @@
     ],
     "name:und_x_variant":[
         "Ilulisat"
+    ],
+    "name:urd_x_preferred":[
+        "\u0627\u0644\u0648\u0644\u06cc\u0633\u0627\u062a"
     ],
     "name:vie_x_preferred":[
         "Ilulissat"
@@ -338,7 +360,7 @@
         }
     ],
     "wof:id":101870707,
-    "wof:lastmodified":1636502624,
+    "wof:lastmodified":1690921781,
     "wof:name":"Ilulissat",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/711/101870711.geojson
+++ b/data/101/870/711/101870711.geojson
@@ -24,8 +24,14 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0632\u064a\u063a\u064a\u0627\u0646\u063a\u0648\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0632\u064a\u062c\u064a\u0627\u0646\u062c\u0648\u062a"
+    ],
     "name:ast_x_preferred":[
         "Qasigiannguit"
+    ],
+    "name:bel_x_preferred":[
+        "\u041a\u0430\u0441\u0456\u0433\u0456\u044f\u043d\u0433\u0443\u0456\u0442"
     ],
     "name:bel_x_variant":[
         "\u041a\u0430\u0441\u044b\u0433\u0456\u044f\u043d\u0433\u0443\u0456\u0442"
@@ -287,7 +293,7 @@
         }
     ],
     "wof:id":101870711,
-    "wof:lastmodified":1636502627,
+    "wof:lastmodified":1690921807,
     "wof:name":"Qasigiannguit",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/713/101870713.geojson
+++ b/data/101/870/713/101870713.geojson
@@ -48,6 +48,9 @@
     "name:frr_x_preferred":[
         "Kangaatsiaq"
     ],
+    "name:ind_x_preferred":[
+        "Kangaatsiaq"
+    ],
     "name:isl_x_preferred":[
         "Kangaatsiaq"
     ],
@@ -65,6 +68,9 @@
     ],
     "name:kor_x_preferred":[
         "\uce78\uac8c\ub97c\ub8e8\uc218\uc545"
+    ],
+    "name:kor_x_variant":[
+        "\uce89\uc637\uc2dc\uc544\ud06c"
     ],
     "name:mkd_x_preferred":[
         "\u041a\u0430\u043d\u0433\u0430\u0440\u0441\u0438\u0458\u0430\u043a"
@@ -150,7 +156,7 @@
         }
     ],
     "wof:id":101870713,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921790,
     "wof:name":"Kangaatsiaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/719/101870719.geojson
+++ b/data/101/870/719/101870719.geojson
@@ -36,6 +36,9 @@
     "name:eng_x_preferred":[
         "Iginniarfik"
     ],
+    "name:eus_x_preferred":[
+        "Iginniarfik"
+    ],
     "name:fra_x_preferred":[
         "Iginniarfik"
     ],
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101870719,
-    "wof:lastmodified":1582358139,
+    "wof:lastmodified":1690921805,
     "wof:name":"Iginniarfik",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/101/870/723/101870723.geojson
+++ b/data/101/870/723/101870723.geojson
@@ -54,6 +54,9 @@
     "name:frr_x_preferred":[
         "Nanortalik"
     ],
+    "name:ind_x_preferred":[
+        "Nanortalik"
+    ],
     "name:isl_x_preferred":[
         "Nanortalik"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:swe_x_preferred":[
         "Nanortalik"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041d\u0430\u043d\u043e\u0440\u0442\u0430\u043b\u0456\u043a"
     ],
     "name:und_x_variant":[
         "Ilivileq"
@@ -162,7 +168,7 @@
         }
     ],
     "wof:id":101870723,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921792,
     "wof:name":"Nanortalik",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/725/101870725.geojson
+++ b/data/101/870/725/101870725.geojson
@@ -21,6 +21,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0631\u0644\u0648\u0643"
+    ],
     "name:cat_x_preferred":[
         "Saarloq"
     ],
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101870725,
-    "wof:lastmodified":1582358138,
+    "wof:lastmodified":1690921789,
     "wof:name":"Saarloq",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/101/870/729/101870729.geojson
+++ b/data/101/870/729/101870729.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u062a\u0633\u064a\u0633\u0648\u0627\u0631\u0633\u0648\u064a\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u062a\u0633\u064a\u0633\u0648\u0627\u0631\u0633\u0648\u064a\u062a"
+    ],
     "name:ceb_x_preferred":[
         "Kitsissuarsuit"
     ],
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101870729,
-    "wof:lastmodified":1582358139,
+    "wof:lastmodified":1690921808,
     "wof:name":"Kitsissuarsuit",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/112/576/665/5/1125766655.geojson
+++ b/data/112/576/665/5/1125766655.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0627\u062a\u0631\u0627\u062c\u064a\u0641\u064a\u062a"
+    ],
     "name:ces_x_preferred":[
         "Itterajivit"
     ],
@@ -29,6 +32,9 @@
         "Kap Hope"
     ],
     "name:dan_x_variant":[
+        "Itterajivit"
+    ],
+    "name:deu_x_preferred":[
         "Itterajivit"
     ],
     "name:eng_x_preferred":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":1125766655,
-    "wof:lastmodified":1566638840,
+    "wof:lastmodified":1690921812,
     "wof:name":"Kap Hope",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/112/582/024/1/1125820241.geojson
+++ b/data/112/582/024/1/1125820241.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u062f\u0646\u0645\u0627\u0631\u0643\u0633\u0647\u0627\u0641\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0646\u0645\u0627\u0631\u0643\u0633\u0647\u0627\u0641\u0646"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u0430\u043d\u043c\u0430\u0440\u043a\u0441\u0445\u0430\u045e\u043d"
+    ],
+    "name:cat_x_preferred":[
+        "Danmarkshavn"
     ],
     "name:dan_x_preferred":[
         "Danmarkshavn"
@@ -38,6 +44,9 @@
         "Danmarkshavn"
     ],
     "name:fra_x_preferred":[
+        "Danmarkshavn"
+    ],
+    "name:frr_x_preferred":[
         "Danmarkshavn"
     ],
     "name:ita_x_preferred":[
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":1125820241,
-    "wof:lastmodified":1566638840,
+    "wof:lastmodified":1690921812,
     "wof:name":"Danmarkshavn",
     "wof:parent_id":85684705,
     "wof:placetype":"locality",

--- a/data/112/583/141/7/1125831417.geojson
+++ b/data/112/583/141/7/1125831417.geojson
@@ -55,6 +55,9 @@
     "name:por_x_preferred":[
         "Kangerluarsoruseq"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u043d\u0433\u0435\u0440\u043b\u0443\u0430\u0440\u0441\u043e\u0440\u0443\u0441\u0435\u043a"
+    ],
     "name:und_x_variant":[
         "Faeringerhavnen"
     ],
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":1125831417,
-    "wof:lastmodified":1566638842,
+    "wof:lastmodified":1690921815,
     "wof:name":"Kangerluarsoruseq",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/583/417/9/1125834179.geojson
+++ b/data/112/583/417/9/1125834179.geojson
@@ -64,6 +64,9 @@
     "name:swe_x_preferred":[
         "Mestersvig"
     ],
+    "name:zho_x_preferred":[
+        "\u6885\u65af\u7279\u65af\u7ef4"
+    ],
     "qs_pg:aaroncc":"GL",
     "qs_pg:gn_country":"GL",
     "qs_pg:gn_fcode":"STNB",
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":1125834179,
-    "wof:lastmodified":1566638842,
+    "wof:lastmodified":1690921815,
     "wof:name":"Mestersvig",
     "wof:parent_id":85684705,
     "wof:placetype":"locality",

--- a/data/112/584/831/5/1125848315.geojson
+++ b/data/112/584/831/5/1125848315.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0631\u0646\u0648\u0643"
+    ],
     "name:ces_x_preferred":[
         "Qoornoq"
     ],
@@ -40,7 +43,13 @@
     "name:ita_x_preferred":[
         "Qoornoq"
     ],
+    "name:jpn_x_preferred":[
+        "\u30af\u30fc\u30a2\u30ce\u30c3\u30af"
+    ],
     "name:nld_x_preferred":[
+        "Qoornoq"
+    ],
+    "name:nob_x_preferred":[
         "Qoornoq"
     ],
     "name:pol_x_preferred":[
@@ -82,7 +91,7 @@
         }
     ],
     "wof:id":1125848315,
-    "wof:lastmodified":1566638841,
+    "wof:lastmodified":1690921814,
     "wof:name":"Qoornoq",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/584/832/5/1125848325.geojson
+++ b/data/112/584/832/5/1125848325.geojson
@@ -79,6 +79,9 @@
     "name:swe_x_preferred":[
         "Qassimiut"
     ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0430\u0441\u0441\u0456\u043c\u0456\u0443\u0442"
+    ],
     "name:und_x_variant":[
         "Kagsimiut"
     ],
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":1125848325,
-    "wof:lastmodified":1566638841,
+    "wof:lastmodified":1690921813,
     "wof:name":"Qassimiut",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/584/837/7/1125848377.geojson
+++ b/data/112/584/837/7/1125848377.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u062a\u0633\u064a\u0633\u0648\u0627\u0631\u0633\u0648\u064a\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u062a\u0633\u064a\u0633\u0648\u0627\u0631\u0633\u0648\u064a\u062a"
+    ],
     "name:ceb_x_preferred":[
         "Kitsissuarsuit"
     ],
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":1125848377,
-    "wof:lastmodified":1566638841,
+    "wof:lastmodified":1690921814,
     "wof:name":"Hunde Ejland",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/590/700/9/1125907009.geojson
+++ b/data/112/590/700/9/1125907009.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u062a\u0648\u0641\u064a\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u062a\u0648\u0641\u064a\u0643"
+    ],
     "name:ast_x_preferred":[
         "Pituffik"
     ],
@@ -66,6 +69,9 @@
     ],
     "name:nob_x_preferred":[
         "Pituffik"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0438\u0442\u0443\u0444\u0444\u0438\u043a"
     ],
     "name:spa_x_preferred":[
         "Pituffik"
@@ -127,7 +133,7 @@
         }
     ],
     "wof:id":1125907009,
-    "wof:lastmodified":1566638837,
+    "wof:lastmodified":1690921811,
     "wof:name":"Dundas",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/593/619/7/1125936197.geojson
+++ b/data/112/593/619/7/1125936197.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0642\u0627\u0633\u064a\u0627\u0631\u0633\u0648\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0642\u0627\u0633\u064a\u0627\u0631\u0633\u0648\u0643"
+    ],
     "name:cat_x_preferred":[
         "Qassiarsuk"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:ita_x_preferred":[
         "Qassiarsuk"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30c3\u30b7\u30a2\u30fc\u30b9\u30c3\u30af"
     ],
     "name:kal_x_preferred":[
         "Qassiarsuk"
@@ -81,6 +87,9 @@
     ],
     "name:und_x_variant":[
         "Kagssiarssuk"
+    ],
+    "name:vie_x_preferred":[
+        "Qassiarsuk"
     ],
     "qs_pg:aaroncc":"GL",
     "qs_pg:gn_country":"GL",
@@ -133,7 +142,7 @@
         }
     ],
     "wof:id":1125936197,
-    "wof:lastmodified":1566638834,
+    "wof:lastmodified":1690921808,
     "wof:name":"Qagssiarssuk",
     "wof:parent_id":85684711,
     "wof:placetype":"locality",

--- a/data/112/593/629/1/1125936291.geojson
+++ b/data/112/593/629/1/1125936291.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0646\u062c\u0631\u0633\u0648\u0627\u062a\u0633\u064a\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0646\u062c\u0631\u0633\u0648\u0627\u062a\u0633\u064a\u0643"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u0982\u0997\u09c7\u09b0\u09b8\u09c1\u09df\u09be\u09a4\u09b8\u09bf\u09df\u09be\u0995"
     ],
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":1125936291,
-    "wof:lastmodified":1636502627,
+    "wof:lastmodified":1690921809,
     "wof:name":"Kangersuatsiaq",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/603/818/5/1126038185.geojson
+++ b/data/112/603/818/5/1126038185.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u062a\u0648\u0641\u064a\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u062a\u0648\u0641\u064a\u0643"
+    ],
     "name:ast_x_preferred":[
         "Pituffik"
     ],
@@ -91,6 +94,9 @@
     "name:por_x_preferred":[
         "Pituffik"
     ],
+    "name:rus_x_preferred":[
+        "\u041f\u0438\u0442\u0443\u0444\u0444\u0438\u043a"
+    ],
     "name:spa_x_preferred":[
         "Pituffik"
     ],
@@ -148,7 +154,7 @@
         }
     ],
     "wof:id":1126038185,
-    "wof:lastmodified":1636502628,
+    "wof:lastmodified":1690921810,
     "wof:name":"Pituffik",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/866/7/1141908667.geojson
+++ b/data/114/190/866/7/1141908667.geojson
@@ -24,11 +24,17 @@
     "name:ara_x_preferred":[
         "\u0625\u064a\u062a\u0648\u0643\u0648\u0631\u062a\u064a\u0631\u0645\u0627\u064a\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u064a\u062a\u0648\u0643\u0648\u0631\u062a\u064a\u0631\u0645\u0627\u064a\u062a"
+    ],
     "name:ast_x_preferred":[
         "Ittoqqortoormiit"
     ],
     "name:bak_x_preferred":[
         "\u0418\u043b\u043b\u043e\u043a\u043a\u043e\u0440\u0442\u043e\u043e\u0440\u043c\u0438\u0443\u0442"
+    ],
+    "name:bel_x_preferred":[
+        "\u0406\u043b\u0430\u043a\u0430\u0440\u0442\u0430\u0430\u0440\u043c\u0456\u0443\u0442"
     ],
     "name:ben_x_preferred":[
         "\u0987\u09a4\u09cd\u09a4\u09cb\u0995\u09cd\u0995\u09cb\u09b0\u09a4\u09c1\u09b0\u09ae\u09bf\u09a4"
@@ -54,6 +60,9 @@
     "name:eng_x_preferred":[
         "Ittoqqortoormiit"
     ],
+    "name:eus_x_preferred":[
+        "Ittoqqortoormiit"
+    ],
     "name:fao_x_preferred":[
         "Illoqqortoormiut"
     ],
@@ -77,6 +86,9 @@
     ],
     "name:hin_x_preferred":[
         "\u0907\u0924\u094b\u0915\u094b\u0930\u094d\u091f\u094b\u092e\u093f\u091f"
+    ],
+    "name:hrv_x_preferred":[
+        "Ittoqqortoormiit"
     ],
     "name:hun_x_preferred":[
         "Ittoqqortoormiit"
@@ -112,6 +124,9 @@
         "Itokortormitas"
     ],
     "name:nld_x_preferred":[
+        "Ittoqqortoormiit"
+    ],
+    "name:nno_x_preferred":[
         "Ittoqqortoormiit"
     ],
     "name:nob_x_preferred":[
@@ -155,6 +170,9 @@
     ],
     "name:vie_x_preferred":[
         "Ittoqqortoormiit"
+    ],
+    "name:yue_x_preferred":[
+        "\u65af\u79d1\u65af\u6bd4\u9b06"
     ],
     "name:zho_x_preferred":[
         "\u65af\u79d1\u65af\u6bd4\u9b06"
@@ -276,7 +294,7 @@
         }
     ],
     "wof:id":1141908667,
-    "wof:lastmodified":1636502628,
+    "wof:lastmodified":1690921816,
     "wof:name":"Ittoqqortoormiit",
     "wof:parent_id":85684729,
     "wof:placetype":"locality",

--- a/data/114/190/867/7/1141908677.geojson
+++ b/data/114/190/867/7/1141908677.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_variant":[
         "\u0643\u064a\u0643\u064a\u0631\u062a\u0627\u0631\u0633\u0648\u0627\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0643\u064a\u0631\u062a\u0627\u0631\u0633\u0648\u0627\u0643"
+    ],
     "name:ast_x_preferred":[
         "Qeqertarsuaq"
     ],
@@ -84,6 +87,9 @@
     "name:ind_x_preferred":[
         "Qeqertasuaq"
     ],
+    "name:ind_x_variant":[
+        "Qeqertarsuaq"
+    ],
     "name:isl_x_preferred":[
         "Qeqertarsuaq"
     ],
@@ -140,6 +146,9 @@
     ],
     "name:tur_x_preferred":[
         "Qeqertarsuaq"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0435\u043a\u0435\u0440\u0442\u0430\u0440\u0441\u0443\u0430\u043a"
     ],
     "name:urd_x_preferred":[
         "\u0642\u06cc\u0642\u0631\u0679\u0627\u0633\u0648\u0627\u0642"
@@ -267,7 +276,7 @@
         }
     ],
     "wof:id":1141908677,
-    "wof:lastmodified":1636502628,
+    "wof:lastmodified":1690921816,
     "wof:name":"Qeqertasuaq",
     "wof:parent_id":85684721,
     "wof:placetype":"locality",

--- a/data/856/332/17/85633217.geojson
+++ b/data/856/332/17/85633217.geojson
@@ -39,8 +39,14 @@
     "name:amh_x_preferred":[
         "\u130d\u122a\u1295\u120b\u1295\u12f5"
     ],
+    "name:ami_x_preferred":[
+        "Greenland"
+    ],
     "name:ang_x_preferred":[
         "Gr\u0113neland"
+    ],
+    "name:anp_x_preferred":[
+        "\u0917\u094d\u0930\u0940\u0928\u0932\u0948\u0902\u0921"
     ],
     "name:ara_x_preferred":[
         "\u062c\u0631\u064a\u0646\u0644\u0627\u0646\u062f"
@@ -148,6 +154,9 @@
     ],
     "name:cze_x_colloquial":[
         "Gronsko"
+    ],
+    "name:dag_x_preferred":[
+        "Greenland"
     ],
     "name:dan_x_colloquial":[
         "Gronland"
@@ -277,6 +286,9 @@
     "name:gom_x_preferred":[
         "\u0917\u094d\u0930\u0940\u0928\u0932\u0901\u0921"
     ],
+    "name:gpe_x_preferred":[
+        "Greenland"
+    ],
     "name:grn_x_preferred":[
         "Gyro\u1ebdl\u00e1ndia"
     ],
@@ -364,6 +376,9 @@
     "name:jpn_x_preferred":[
         "\u30b0\u30ea\u30fc\u30f3\u30e9\u30f3\u30c9"
     ],
+    "name:kab_x_preferred":[
+        "Grinland"
+    ],
     "name:kal_x_preferred":[
         "Kalaallit Nunaat"
     ],
@@ -381,6 +396,9 @@
     ],
     "name:kbp_x_preferred":[
         "Kroweland\u0269"
+    ],
+    "name:khm_x_preferred":[
+        "\u1780\u17d2\u179a\u17bc\u17a2\u17b7\u1793\u17a1\u1784\u17cb"
     ],
     "name:kik_x_preferred":[
         "Grinlandi"
@@ -434,6 +452,9 @@
     "name:lit_x_preferred":[
         "Grenlandija"
     ],
+    "name:lld_x_preferred":[
+        "Groenlandia"
+    ],
     "name:ltz_x_preferred":[
         "Gr\u00f6nland"
     ],
@@ -461,6 +482,9 @@
     "name:mar_x_variant":[
         "\u0917\u094d\u0930\u0940\u0928\u0932\u0902\u0921"
     ],
+    "name:mdf_x_preferred":[
+        "\u0413\u0440\u044d\u043d\u043b\u0430\u043d\u0434\u0438\u044f"
+    ],
     "name:mhr_x_preferred":[
         "\u0413\u0440\u0435\u043d\u043b\u0430\u043d\u0434\u0438\u0439"
     ],
@@ -477,7 +501,14 @@
         "Grinlandja"
     ],
     "name:mlt_x_variant":[
-        "Groenlandja"
+        "Groenlandja",
+        "Greenland"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd2\uabed\uabd4\uabe4\uabdf\uabc2\uabe6\uabdf"
+    ],
+    "name:mnw_x_preferred":[
+        "\u1002\u101b\u102d\u1014\u103a\u101c\u102c\u1014\u103a"
     ],
     "name:mon_x_preferred":[
         "\u0413\u0440\u0435\u043d\u043b\u0430\u043d\u0434"
@@ -607,6 +638,9 @@
         "Gro\u00eanlandia",
         "Groenl\u00e2ndia"
     ],
+    "name:pus_x_preferred":[
+        "\u06ab\u0631\u064a\u0646\u0644\u06d0\u0646\u0689"
+    ],
     "name:que_x_preferred":[
         "Kalalit Suyu"
     ],
@@ -647,6 +681,9 @@
     "name:sgs_x_preferred":[
         "Grenland\u0117j\u0117"
     ],
+    "name:shn_x_preferred":[
+        "\u1075\u101b\u102d\u107c\u103a\u1038\u101c\u1085\u107c\u103a\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0d9c\u0dca\u200d\u0dbb\u0dd3\u0db1\u0dca\u0dbd\u0db1\u0dca\u0dad\u0dba"
     ],
@@ -667,6 +704,9 @@
     ],
     "name:sna_x_preferred":[
         "Greenland"
+    ],
+    "name:snd_x_preferred":[
+        "\u06af\u0631\u064a\u0646 \u0644\u064a\u0646\u068a"
     ],
     "name:som_x_preferred":[
         "Griinland"
@@ -707,6 +747,9 @@
     "name:szl_x_preferred":[
         "Grynlandyjo"
     ],
+    "name:szl_x_variant":[
+        "Grynlandyj\u014f"
+    ],
     "name:szy_x_preferred":[
         "Greenland"
     ],
@@ -718,6 +761,9 @@
     ],
     "name:tat_x_preferred":[
         "\u0413\u0440\u0435\u043d\u043b\u0430\u043d\u0434\u0438\u044f"
+    ],
+    "name:tay_x_preferred":[
+        "Greenland"
     ],
     "name:tel_x_preferred":[
         "\u0c17\u0c4d\u0c30\u0c40\u0c28\u0c4d\u200c\u0c32\u0c3e\u0c02\u0c21\u0c4d"
@@ -740,14 +786,26 @@
     "name:tir_x_preferred":[
         "\u130d\u122a\u1295\u120b\u1295\u12f5"
     ],
+    "name:tok_x_preferred":[
+        "ma Kalalinuna"
+    ],
     "name:ton_x_preferred":[
         "Kulinileni"
     ],
     "name:tpi_x_preferred":[
         "Greenland"
     ],
+    "name:trv_x_preferred":[
+        "Greenland"
+    ],
+    "name:tuk_x_preferred":[
+        "Grenlandi\u00fda"
+    ],
     "name:tur_x_preferred":[
         "Gr\u00f6nland"
+    ],
+    "name:udm_x_preferred":[
+        "\u0413\u0440\u0435\u043d\u043b\u0430\u043d\u0434\u0438\u044f"
     ],
     "name:uig_x_preferred":[
         "\u06af\u0631\u06d0\u0646\u0644\u0627\u0646\u062f\u0649\u064a\u06d5"
@@ -771,6 +829,12 @@
     ],
     "name:vec_x_preferred":[
         "Groenlandia"
+    ],
+    "name:vec_x_variant":[
+        "Groenl\u00e0ndia"
+    ],
+    "name:vep_x_preferred":[
+        "Grenland"
     ],
     "name:vie_x_preferred":[
         "Greenland"
@@ -1051,7 +1115,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1618362692,
+    "wof:lastmodified":1690921775,
     "wof:name":"Greenland",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.