### PR TITLE
gl concordances, placetype local, and more

### DIFF
--- a/data/856/332/17/85633217.geojson
+++ b/data/856/332/17/85633217.geojson
@@ -1083,6 +1083,7 @@
         "hasc:id":"GL",
         "icao:code":"OY",
         "ioc:id":"GRL",
+        "iso:code":"GL",
         "itu:id":"GRL",
         "loc:id":"n79059221",
         "m49:code":"304",
@@ -1096,6 +1097,7 @@
         "wd:id":"Q223",
         "wmo:id":"GL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GL",
     "wof:country_alpha3":"GRL",
     "wof:geom_alt":[
@@ -1119,7 +1121,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1694639639,
+    "wof:lastmodified":1695881301,
     "wof:name":"Greenland",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/847/05/85684705.geojson
+++ b/data/856/847/05/85684705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":340.277856,
-    "geom:area_square_m":883276969967.579468,
+    "geom:area_square_m":883276987225.039062,
     "geom:bbox":"-62.034577,71.0,-11.413386,83.653984",
     "geom:latitude":77.87484,
     "geom:longitude":-34.921802,
@@ -67,10 +67,16 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "hasc:id":"GL.UO"
+        "hasc:id":"GL.UO",
+        "iso:code":"GL-AV",
+        "qs:local_id":"9061"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GL",
-    "wof:geomhash":"9fd14ef64ffacf6d5438cc085b9054f4",
+    "wof:geomhash":"3fd576f5908dbad9a8320c73536c70c4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -85,7 +91,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1627522157,
+    "wof:lastmodified":1695884754,
     "wof:name":"Nuna Allanngutsaaaliugaq",
     "wof:parent_id":85633217,
     "wof:placetype":"region",

--- a/data/856/847/11/85684711.geojson
+++ b/data/856/847/11/85684711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.565995,
-    "geom:area_square_m":50568493980.424469,
+    "geom:area_square_m":50568500226.901367,
     "geom:bbox":"-48.258972,59.781037,-42.064607,62.793377",
     "geom:latitude":61.376259,
     "geom:longitude":-44.441105,
@@ -175,11 +175,17 @@
         "gn:id":7602005,
         "gp:id":-99,
         "hasc:id":"GL.KU",
+        "iso:code":"GL-KU",
         "iso:id":"GL-KU",
+        "qs:local_id":"9055",
         "unlc:id":"GL-KU"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GL",
-    "wof:geomhash":"c485173d20523c239d70ac0c4aa16e96",
+    "wof:geomhash":"1b601a2947c1cad9d51389785592c8cc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -194,7 +200,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1636502623,
+    "wof:lastmodified":1695884938,
     "wof:name":"Kommune Kujalleq",
     "wof:parent_id":85633217,
     "wof:placetype":"region",

--- a/data/856/847/17/85684717.geojson
+++ b/data/856/847/17/85684717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":21.264598,
-    "geom:area_square_m":105123135376.236618,
+    "geom:area_square_m":105123140279.039688,
     "geom:bbox":"-53.975849,64.577408,-44.026074,67.776223",
     "geom:latitude":66.432584,
     "geom:longitude":-48.844948,
@@ -178,11 +178,17 @@
         "gn:id":7602006,
         "gp:id":20069858,
         "hasc:id":"GL.QT",
+        "iso:code":"GL-QE",
         "iso:id":"GL-QE",
+        "qs:local_id":"9057",
         "unlc:id":"GL-QE"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GL",
-    "wof:geomhash":"546f081e38a65aeef4983714931d26e2",
+    "wof:geomhash":"c0b248fa52c894dbd84cf31f5ce904d3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -197,7 +203,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1636502624,
+    "wof:lastmodified":1695884939,
     "wof:name":"Qeqqata Kommunia",
     "wof:parent_id":85633217,
     "wof:placetype":"region",

--- a/data/856/847/21/85684721.geojson
+++ b/data/856/847/21/85684721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":179.661998,
-    "geom:area_square_m":566973859455.635376,
+    "geom:area_square_m":566973858525.390015,
     "geom:bbox":"-73.237213,67.483429,-44.039101,81.200287",
     "geom:latitude":75.155695,
     "geom:longitude":-54.106539,
@@ -169,11 +169,17 @@
         "gn:id":7602003,
         "gp:id":-99,
         "hasc:id":"GL.QS",
+        "iso:code":"GL-QA",
         "iso:id":"GL-QA",
+        "qs:local_id":"9058",
         "unlc:id":"GL-QA"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GL",
-    "wof:geomhash":"f7f0504850a13639acb4e99eed04ae71",
+    "wof:geomhash":"56d92530b4f5a437a4f56a44f93bdbf6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -188,7 +194,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1636502624,
+    "wof:lastmodified":1695884939,
     "wof:name":"Qaasuitsup Kommunia",
     "wof:parent_id":85633217,
     "wof:placetype":"region",

--- a/data/856/847/29/85684729.geojson
+++ b/data/856/847/29/85684729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":114.420045,
-    "geom:area_square_m":543258798399.808472,
+    "geom:area_square_m":543258802065.879272,
     "geom:bbox":"-52.164646,60.967731,-21.46186,71.942802",
     "geom:latitude":67.400332,
     "geom:longitude":-38.631169,
@@ -154,11 +154,17 @@
         "gn:id":7602007,
         "gp:id":20069859,
         "hasc:id":"GL.SE",
+        "iso:code":"GL-SM",
         "iso:id":"GL-SM",
+        "qs:local_id":"9056",
         "unlc:id":"GL-SM"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GL",
-    "wof:geomhash":"495f1c5df1eaaa786ee2ab772d992d31",
+    "wof:geomhash":"c121c2813e102979201062e75a0e4245",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -173,7 +179,7 @@
     "wof:lang_x_spoken":[
         "kal"
     ],
-    "wof:lastmodified":1636502623,
+    "wof:lastmodified":1695884938,
     "wof:name":"Kommuneqarfik Sermersooq",
     "wof:parent_id":85633217,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.